### PR TITLE
Fix Markdown highlighting after MDXTab frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 dist/
 *.vsix
-.vscode/
 /dev/notes
 *.code-workspace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "outFiles": [
         "${workspaceFolder}/packages/vscode/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: build -w @mdxtab/vscode"
+      "preLaunchTask": "npm: build -w mdxtab"
     }
   ]
 }

--- a/dev/examples/issue-15-repro.md
+++ b/dev/examples/issue-15-repro.md
@@ -1,0 +1,29 @@
+---
+mdxtab: "1.0"
+tables:
+  demo:
+    columns: [id, value]
+    aggregates:
+      total: sum(value)
+---
+
+# Issue 15 Repro
+
+## demo
+| id | value |
+| --- | --- |
+| a | 1 |
+| b | 2 |
+
+---
+
+## Markdown After Horizontal Rule
+
+This content should still be highlighted as normal markdown.
+
+- List item A
+- List item B
+
+**Bold**, *italic*, and a [link](https://example.com) should all render normally.
+
+{{ demo.total }}

--- a/packages/vscode/syntaxes/mdxtab.markdown.tmLanguage.json
+++ b/packages/vscode/syntaxes/mdxtab.markdown.tmLanguage.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "frontmatter": {
-      "begin": "^(---)\\s*$",
+      "begin": "^(---)\\s*$(?=[\\s\\S]*?^\\s*mdxtab\\s*:[\\s\\S]*?^---\\s*$)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.frontmatter.mdxtab"


### PR DESCRIPTION
Fix TextMate frontmatter detection so MDXTab only activates when mdxtab exists in the frontmatter block, preventing --- HRs from breaking Markdown highlighting.

Add a repro file to validate highlighting after a horizontal rule.

Fix the F5 preLaunch task label to match the existing build task.

Notes:
This PR also un-ignores .vscode so launch configs can be committed.