### PR TITLE
Fix TextMate frontmatter anchoring

### DIFF
--- a/packages/vscode/syntaxes/mdxtab.markdown.tmLanguage.json
+++ b/packages/vscode/syntaxes/mdxtab.markdown.tmLanguage.json
@@ -43,43 +43,6 @@
         }
       ]
     },
-    "frontmatterTableEntry": {
-      "patterns": [
-        {
-          "match": "^\\s*([A-Za-z0-9_]+)\\s*:(?=\\s*$)",
-          "name": "entity.name.type.mdxtab.table",
-          "captures": {
-            "1": {
-              "name": "entity.name.type.mdxtab.table"
-            }
-          }
-        }
-      ]
-    },
-    "frontmatterNameValue": {
-      "patterns": [
-        {
-          "match": "^\\s*([A-Za-z0-9_]+)\\s*:\\s*(.+)$",
-          "name": "meta.mdxtab.entry",
-          "captures": {
-            "1": {
-              "name": "variable.other.mdxtab.name"
-            },
-            "2": {
-              "name": "string.unquoted.mdxtab.value"
-            }
-          }
-        }
-      ]
-    },
-    "frontmatterValues": {
-      "patterns": [
-        {
-          "match": "^\\s*[A-Za-z0-9_]+\\s*:\\s*.+$",
-          "name": "string.unquoted.mdxtab"
-        }
-      ]
-    },
     "interpolation": {
       "match": "\\{\\{\\s*([A-Za-z0-9_]+)\\.([A-Za-z0-9_]+)\\s*\\}\\}",
       "name": "meta.mdxtab.interpolation",


### PR DESCRIPTION
Fixes frontmatter highlighting by anchoring the opening --- to the start of the document using \A, which is compatible with TextMate single-line regex behavior.

Reference:
- TextMate language grammars match regexes per line, so multi-line lookaheads do not work: https://macromates.com/manual/en/language_grammars
- Oniguruma anchors include \A (start of string): https://macromates.com/manual/en/regular_expressions