### PR TITLE
Resolve missing VS Code schema command

### DIFF
--- a/dev/work-items/27-vscode-schema-command.md
+++ b/dev/work-items/27-vscode-schema-command.md
@@ -40,11 +40,11 @@ Task 1 notes:
 
 Task 2 notes:
 - Added command contribution in `packages/vscode/package.json`:
-	- `mdxtab.showTableSchema` / `MDXTab: Show Table Schema`
+  - `mdxtab.showTableSchema` / `MDXTab: Show Table Schema`
 - Registered `mdxtab.showTableSchema` in `packages/vscode/src/extension.ts` with user-visible behavior:
-	- reads active MDXTab frontmatter schema
-	- opens a preview markdown document containing JSON schema for `tables`
-	- shows clear messages for missing active editor, non-MDXTab files, empty schema, and parse failures
+  - reads active MDXTab frontmatter schema
+  - opens a preview markdown document containing JSON schema for `tables`
+  - shows clear messages for missing active editor, non-MDXTab files, empty schema, and parse failures
 - Kept descope path unchecked because implementation path is selected for v1.0.
 
 ### 3. Tests and docs alignment
@@ -54,8 +54,8 @@ Task 2 notes:
 
 Task 3 notes:
 - Extended `packages/vscode/src/__tests__/extension.smoke.spec.ts` with schema-command behavior checks:
-	- opens a schema document for a valid MDXTab file
-	- warns for non-MDXTab files
+  - opens a schema document for a valid MDXTab file
+  - warns for non-MDXTab files
 - Updated user docs command surface in `docs/vscode-extension.md` to include `MDXTab: Show Table Schema` and usage in the typical flow.
 - Updated `packages/vscode/README.md` command list to include validate + schema commands so extension docs stay aligned.
 - Verified active docs/spec references now align with the implemented command set (`renderPreview`, `validateDocument`, `showTableSchema`).
@@ -67,12 +67,12 @@ Task 3 notes:
 
 Task 4 notes:
 - Ran final validation in the VS Code workspace:
-	- `npm run -w mdxtab test` passed (`6/6` tests).
-	- `npm run -w mdxtab build` passed.
+  - `npm run -w mdxtab test` passed (`6/6` tests).
+  - `npm run -w mdxtab build` passed.
 - Verified command surface alignment across implementation and docs/spec:
-	- `packages/vscode/package.json` contributes `mdxtab.renderPreview`, `mdxtab.validateDocument`, and `mdxtab.showTableSchema`.
-	- `docs/vscode-extension.md` documents all three core commands.
-	- `specs/technical-design.md` command list includes `MDXTab: Show Table Schema`.
+  - `packages/vscode/package.json` contributes `mdxtab.renderPreview`, `mdxtab.validateDocument`, and `mdxtab.showTableSchema`.
+  - `docs/vscode-extension.md` documents all three core commands.
+  - `specs/technical-design.md` command list includes `MDXTab: Show Table Schema`.
 - Work item closed as DONE for issue #29 implementation path.
 
 ## Acceptance criteria

--- a/dev/work-items/27-vscode-schema-command.md
+++ b/dev/work-items/27-vscode-schema-command.md
@@ -1,7 +1,7 @@
 # Work Item: Resolve missing VS Code schema command
 
 ## Status
-- State: TODO
+- State: DONE
 - Priority: HIGH
 - Branch: issue-29-vscode-schema-command
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/29
@@ -61,14 +61,21 @@ Task 3 notes:
 - Verified active docs/spec references now align with the implemented command set (`renderPreview`, `validateDocument`, `showTableSchema`).
 
 ### 4. Validation and completion
-- [ ] Run build/test validation for affected packages.
-- [ ] Verify extension command surface matches docs/spec outcomes.
-- [ ] Update this work item with completion notes.
+- [x] Run build/test validation for affected packages.
+- [x] Verify extension command surface matches docs/spec outcomes.
+- [x] Update this work item with completion notes.
 
 Task 4 notes:
-- Pending.
+- Ran final validation in the VS Code workspace:
+	- `npm run -w mdxtab test` passed (`6/6` tests).
+	- `npm run -w mdxtab build` passed.
+- Verified command surface alignment across implementation and docs/spec:
+	- `packages/vscode/package.json` contributes `mdxtab.renderPreview`, `mdxtab.validateDocument`, and `mdxtab.showTableSchema`.
+	- `docs/vscode-extension.md` documents all three core commands.
+	- `specs/technical-design.md` command list includes `MDXTab: Show Table Schema`.
+- Work item closed as DONE for issue #29 implementation path.
 
 ## Acceptance criteria
-- [ ] No unresolved mismatch remains between intended v1.0 VS Code command surface and docs/spec references.
-- [ ] Chosen path (implement or descope) is fully reflected in code, docs, and tests.
-- [ ] Validation commands pass for impacted areas.
+- [x] No unresolved mismatch remains between intended v1.0 VS Code command surface and docs/spec references.
+- [x] Chosen path (implement or descope) is fully reflected in code, docs, and tests.
+- [x] Validation commands pass for impacted areas.

--- a/dev/work-items/27-vscode-schema-command.md
+++ b/dev/work-items/27-vscode-schema-command.md
@@ -34,12 +34,18 @@ Task 1 notes:
 - Issue #29 confirms acceptance can be either implement or explicit descope. For v1.0, decision is to implement the schema command to preserve product/spec alignment.
 
 ### 2. Implementation or descope execution
-- [ ] If implementing: add command contribution, handler, and user-visible behavior.
+- [x] If implementing: add command contribution, handler, and user-visible behavior.
 - [ ] If descoping: remove/adjust references in specs/docs to reflect actual v1.0 surface.
-- [ ] Ensure command IDs/messages are consistent across manifest and code.
+- [x] Ensure command IDs/messages are consistent across manifest and code.
 
 Task 2 notes:
-- Pending.
+- Added command contribution in `packages/vscode/package.json`:
+	- `mdxtab.showTableSchema` / `MDXTab: Show Table Schema`
+- Registered `mdxtab.showTableSchema` in `packages/vscode/src/extension.ts` with user-visible behavior:
+	- reads active MDXTab frontmatter schema
+	- opens a preview markdown document containing JSON schema for `tables`
+	- shows clear messages for missing active editor, non-MDXTab files, empty schema, and parse failures
+- Kept descope path unchecked because implementation path is selected for v1.0.
 
 ### 3. Tests and docs alignment
 - [ ] Add or update tests covering chosen path.

--- a/dev/work-items/27-vscode-schema-command.md
+++ b/dev/work-items/27-vscode-schema-command.md
@@ -1,0 +1,63 @@
+# Work Item: Resolve missing VS Code schema command
+
+## Status
+- State: TODO
+- Priority: HIGH
+- Branch: issue-29-vscode-schema-command
+- Issue: https://github.com/Frank-Yong/MDXTab/issues/29
+
+## Description
+Resolve the missing VS Code schema command so shipped extension behavior matches documented/spec expectations before v1.0.
+
+## Background
+
+### Problem summary
+- A VS Code schema-related command is expected in product/spec context but is currently missing in the extension command surface.
+- This creates a product/spec mismatch and potential user confusion near v1.0.
+
+### Desired outcome
+- Confirm intended command behavior and user flow.
+- Either implement the command end-to-end or explicitly descope and align all docs/spec references.
+- Keep extension command surface and docs internally consistent.
+
+## Tasks
+
+### 1. Discovery and decision
+- [x] Locate all references to the missing schema command in specs, docs, and extension manifest/code.
+- [x] Confirm intended behavior and scope for v1.0.
+- [x] Choose one path: implement now, or descope with explicit documentation/spec updates.
+
+Task 1 notes:
+- References found in `specs/development-spec.md` and `specs/technical-design.md` explicitly include a command to show the current file schema.
+- `packages/vscode/package.json` currently contributes only `mdxtab.renderPreview` and `mdxtab.validateDocument`.
+- `packages/vscode/src/extension.ts` currently registers only render-preview and validate-document commands; no schema command registration exists.
+- Issue #29 confirms acceptance can be either implement or explicit descope. For v1.0, decision is to implement the schema command to preserve product/spec alignment.
+
+### 2. Implementation or descope execution
+- [ ] If implementing: add command contribution, handler, and user-visible behavior.
+- [ ] If descoping: remove/adjust references in specs/docs to reflect actual v1.0 surface.
+- [ ] Ensure command IDs/messages are consistent across manifest and code.
+
+Task 2 notes:
+- Pending.
+
+### 3. Tests and docs alignment
+- [ ] Add or update tests covering chosen path.
+- [ ] Update user docs where command availability/usage is described.
+- [ ] Confirm no stale references remain.
+
+Task 3 notes:
+- Pending.
+
+### 4. Validation and completion
+- [ ] Run build/test validation for affected packages.
+- [ ] Verify extension command surface matches docs/spec outcomes.
+- [ ] Update this work item with completion notes.
+
+Task 4 notes:
+- Pending.
+
+## Acceptance criteria
+- [ ] No unresolved mismatch remains between intended v1.0 VS Code command surface and docs/spec references.
+- [ ] Chosen path (implement or descope) is fully reflected in code, docs, and tests.
+- [ ] Validation commands pass for impacted areas.

--- a/dev/work-items/27-vscode-schema-command.md
+++ b/dev/work-items/27-vscode-schema-command.md
@@ -48,12 +48,17 @@ Task 2 notes:
 - Kept descope path unchecked because implementation path is selected for v1.0.
 
 ### 3. Tests and docs alignment
-- [ ] Add or update tests covering chosen path.
-- [ ] Update user docs where command availability/usage is described.
-- [ ] Confirm no stale references remain.
+- [x] Add or update tests covering chosen path.
+- [x] Update user docs where command availability/usage is described.
+- [x] Confirm no stale references remain.
 
 Task 3 notes:
-- Pending.
+- Extended `packages/vscode/src/__tests__/extension.smoke.spec.ts` with schema-command behavior checks:
+	- opens a schema document for a valid MDXTab file
+	- warns for non-MDXTab files
+- Updated user docs command surface in `docs/vscode-extension.md` to include `MDXTab: Show Table Schema` and usage in the typical flow.
+- Updated `packages/vscode/README.md` command list to include validate + schema commands so extension docs stay aligned.
+- Verified active docs/spec references now align with the implemented command set (`renderPreview`, `validateDocument`, `showTableSchema`).
 
 ### 4. Validation and completion
 - [ ] Run build/test validation for affected packages.

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -11,6 +11,7 @@ The extension provides preview rendering and diagnostics inside markdown files.
 
 - `MDXTab: Render Preview` (`mdxtab.renderPreview`)
 - `MDXTab: Validate Document` (`mdxtab.validateDocument`)
+- `MDXTab: Show Table Schema` (`mdxtab.showTableSchema`)
 
 ## Typical flow
 
@@ -18,6 +19,7 @@ The extension provides preview rendering and diagnostics inside markdown files.
 2. Save or edit to trigger diagnostics.
 3. Run render preview command to inspect computed output.
 4. Use validate command to get explicit diagnostic count/status.
+5. Use show table schema command to inspect parsed `tables` frontmatter as JSON.
 
 ## Key settings
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -3,6 +3,8 @@
 **Markdown Extended Tables**
 
 - Command: **MDXTab: Render Preview** (`mdxtab.renderPreview`) — renders the active Markdown file through the MDXTab compiler into a preview document.
+- Command: **MDXTab: Validate Document** (`mdxtab.validateDocument`) — validates the active Markdown file and reports diagnostic count/status.
+- Command: **MDXTab: Show Table Schema** (`mdxtab.showTableSchema`) — opens a markdown view with the parsed `tables` frontmatter schema as JSON.
 - Diagnostics: recompiles on open/change/save; errors surface as markdown diagnostics at the top of the file.
 - Preview scheme: `mdxtab-preview:` opens a virtual document with the rendered output (frontmatter + interpolated aggregates).
 - **Computed column preview**: columns defined in frontmatter `computed` are rendered in the Markdown preview with their evaluated per-row values. Columns already authored as headers have their empty cells filled in; columns not in the source table are appended automatically.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -98,6 +98,10 @@
       {
         "command": "mdxtab.validateDocument",
         "title": "MDXTab: Validate Document"
+      },
+      {
+        "command": "mdxtab.showTableSchema",
+        "title": "MDXTab: Show Table Schema"
       }
     ]
   },

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -303,6 +303,7 @@ describe("vscode extension smoke", () => {
     expect(state.previewProvider).toBeDefined();
     expect(state.commands.has("mdxtab.renderPreview")).toBe(true);
     expect(state.commands.has("mdxtab.validateDocument")).toBe(true);
+    expect(state.commands.has("mdxtab.showTableSchema")).toBe(true);
     expect(state.openHandlers.length).toBeGreaterThan(0);
   });
 

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -12,6 +12,8 @@ const state = {
   diagnosticDeleteCalls: [] as MockUri[],
   executedCommands: [] as Array<{ command: string; args: unknown[] }>,
   documents: new Map<string, MockDocument>(),
+  virtualDocumentContents: [] as string[],
+  shownDocumentCount: 0,
   window: undefined as
     | undefined
     | {
@@ -209,7 +211,15 @@ vi.mock("vscode", () => {
       state.saveHandlers.push(callback);
       return { dispose: () => undefined };
     }),
-    openTextDocument: vi.fn(async (uri: MockUri) => state.documents.get(uri.toString())),
+    openTextDocument: vi.fn(async (input: MockUri | { language?: string; content?: string }) => {
+      if (input instanceof MockUri) return state.documents.get(input.toString());
+      if (typeof input === "object" && input && "content" in input) {
+        const content = String(input.content ?? "");
+        state.virtualDocumentContents.push(content);
+        return createDoc(MockUri.from({ scheme: "untitled", path: `/virtual-${state.virtualDocumentContents.length}.md` }), content);
+      }
+      return undefined;
+    }),
   };
 
   const languages = {
@@ -231,6 +241,10 @@ vi.mock("vscode", () => {
     showErrorMessage: vi.fn(),
     showInformationMessage: vi.fn(),
     showWarningMessage: vi.fn(),
+    showTextDocument: vi.fn(async () => {
+      state.shownDocumentCount += 1;
+      return undefined;
+    }),
   };
   state.window = window;
 
@@ -260,12 +274,13 @@ vi.mock("vscode", () => {
 
 const compileMdxtab = vi.fn(() => ({ rendered: "rendered-output" }));
 const validateMdxtab = vi.fn(() => ({ diagnostics: [] as Array<Record<string, unknown>> }));
+const parseFrontmatter = vi.fn(() => ({ tables: {} }));
 
 vi.mock("../core/index.js", () => ({
   compileMdxtab,
   validateMdxtab,
   toDiagnostic: vi.fn(() => ({ code: "E_TEST", message: "boom", severity: "error" })),
-  parseFrontmatter: vi.fn(() => ({ tables: {} })),
+  parseFrontmatter,
   parseMarkdownTables: vi.fn(() => []),
 }));
 
@@ -282,6 +297,8 @@ describe("vscode extension smoke", () => {
     state.diagnosticDeleteCalls.length = 0;
     state.executedCommands.length = 0;
     state.documents.clear();
+    state.virtualDocumentContents.length = 0;
+    state.shownDocumentCount = 0;
     if (state.window) {
       state.window.activeTextEditor = undefined;
       state.window.visibleTextEditors.length = 0;
@@ -291,6 +308,8 @@ describe("vscode extension smoke", () => {
     compileMdxtab.mockReturnValue({ rendered: "rendered-output" });
     validateMdxtab.mockReset();
     validateMdxtab.mockReturnValue({ diagnostics: [] });
+    parseFrontmatter.mockReset();
+    parseFrontmatter.mockReturnValue({ tables: {} });
   });
 
   it("activates and registers core commands/providers", async () => {
@@ -385,5 +404,59 @@ describe("vscode extension smoke", () => {
     expect(state.executedCommands.length).toBe(1);
     expect(state.executedCommands[0].command).toBe("vscode.open");
     expect(String(state.executedCommands[0].args[0])).toContain("mdxtab-preview");
+  });
+
+  it("executes show-table-schema command and opens a schema document", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        expenses: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+    });
+
+    const sourceUri = MockUri.from({ scheme: "file", path: "/tmp/schema.md" });
+    const sourceDoc = createDoc(
+      sourceUri,
+      "---\nmdxtab: \"1.0\"\ntables:\n  expenses:\n    columns: [id, amount]\n---\n\n## expenses\n| id | amount |\n|---|---|\n| a | 1 |",
+    );
+    (vscode.window as { activeTextEditor?: { document: MockDocument } }).activeTextEditor = { document: sourceDoc };
+
+    const command = state.commands.get("mdxtab.showTableSchema");
+    expect(command).toBeDefined();
+
+    await command?.();
+
+    expect(state.shownDocumentCount).toBe(1);
+    expect(state.virtualDocumentContents.length).toBe(1);
+    expect(state.virtualDocumentContents[0]).toContain("# MDXTab Table Schema");
+    expect(state.virtualDocumentContents[0]).toContain('"expenses"');
+  });
+
+  it("warns when show-table-schema runs on a non-MDXTab file", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    const sourceUri = MockUri.from({ scheme: "file", path: "/tmp/plain.md" });
+    const sourceDoc = createDoc(sourceUri, "# plain markdown\n\nno mdxtab frontmatter here");
+    (vscode.window as { activeTextEditor?: { document: MockDocument } }).activeTextEditor = { document: sourceDoc };
+
+    const command = state.commands.get("mdxtab.showTableSchema");
+    expect(command).toBeDefined();
+
+    await command?.();
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      "MDXTab: active file does not look like an MDXTab document",
+    );
+    expect(state.shownDocumentCount).toBe(0);
   });
 });

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -459,4 +459,32 @@ describe("vscode extension smoke", () => {
     );
     expect(state.shownDocumentCount).toBe(0);
   });
+
+  it("surfaces parse error details when show-table-schema cannot parse frontmatter", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockImplementation(() => {
+      throw new Error("invalid YAML near line 2");
+    });
+
+    const sourceUri = MockUri.from({ scheme: "file", path: "/tmp/bad-frontmatter.md" });
+    const sourceDoc = createDoc(
+      sourceUri,
+      "---\nmdxtab: \"1.0\"\ntables: [\n---\n\n## t\n| id | value |\n|---|---|\n| a | 1 |",
+    );
+    (vscode.window as { activeTextEditor?: { document: MockDocument } }).activeTextEditor = { document: sourceDoc };
+
+    const command = state.commands.get("mdxtab.showTableSchema");
+    expect(command).toBeDefined();
+
+    await command?.();
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      "MDXTab: could not read table schema from frontmatter: invalid YAML near line 2",
+    );
+    expect(state.shownDocumentCount).toBe(0);
+  });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1139,6 +1139,49 @@ export function activate(context: ExtensionContext) {
   });
   context.subscriptions.push(validateCommand);
 
+  const showSchemaCommand = commands.registerCommand("mdxtab.showTableSchema", async () => {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+      window.showErrorMessage("No active editor to inspect");
+      return;
+    }
+
+    const text = editor.document.getText();
+    if (!looksLikeMdxtab(text)) {
+      window.showWarningMessage("MDXTab: active file does not look like an MDXTab document");
+      return;
+    }
+
+    try {
+      const frontmatter = parseFrontmatter(text);
+      const tableCount = Object.keys(frontmatter.tables).length;
+      if (tableCount === 0) {
+        window.showInformationMessage("MDXTab: no table schemas found in frontmatter");
+        return;
+      }
+
+      const schemaJson = JSON.stringify({ tables: frontmatter.tables }, null, 2);
+      const schemaDoc = await workspace.openTextDocument({
+        language: "markdown",
+        content: [
+          "# MDXTab Table Schema",
+          "",
+          `Source: ${editor.document.uri.fsPath || editor.document.uri.toString()}`,
+          "",
+          "```json",
+          schemaJson,
+          "```",
+          "",
+        ].join("\n"),
+      });
+
+      await window.showTextDocument(schemaDoc, { preview: true });
+    } catch {
+      window.showErrorMessage("MDXTab: could not read table schema from frontmatter");
+    }
+  });
+  context.subscriptions.push(showSchemaCommand);
+
   const active = window.activeTextEditor?.document;
   if (active) updateDiagnostics(active, diagnostics);
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1152,14 +1152,22 @@ export function activate(context: ExtensionContext) {
       return;
     }
 
+    let frontmatter: ReturnType<typeof parseFrontmatter>;
     try {
-      const frontmatter = parseFrontmatter(text);
-      const tableCount = Object.keys(frontmatter.tables).length;
-      if (tableCount === 0) {
-        window.showInformationMessage("MDXTab: no table schemas found in frontmatter");
-        return;
-      }
+      frontmatter = parseFrontmatter(text);
+    } catch (err) {
+      const detail = err instanceof Error ? `: ${err.message}` : "";
+      window.showErrorMessage(`MDXTab: could not read table schema from frontmatter${detail}`);
+      return;
+    }
 
+    const tableCount = Object.keys(frontmatter.tables).length;
+    if (tableCount === 0) {
+      window.showInformationMessage("MDXTab: no table schemas found in frontmatter");
+      return;
+    }
+
+    try {
       const schemaJson = JSON.stringify({ tables: frontmatter.tables }, null, 2);
       const schemaDoc = await workspace.openTextDocument({
         language: "markdown",
@@ -1176,8 +1184,9 @@ export function activate(context: ExtensionContext) {
       });
 
       await window.showTextDocument(schemaDoc, { preview: true });
-    } catch {
-      window.showErrorMessage("MDXTab: could not read table schema from frontmatter");
+    } catch (err) {
+      const detail = err instanceof Error ? `: ${err.message}` : "";
+      window.showErrorMessage(`MDXTab: could not open schema view${detail}`);
     }
   });
   context.subscriptions.push(showSchemaCommand);


### PR DESCRIPTION
## Summary
- implement MDXTab: Show Table Schema (mdxtab.showTableSchema) in the VS Code extension
- contribute the new command in the extension manifest and register a handler in extension runtime
- display the active file 	ables frontmatter schema in a generated markdown view (JSON block)
- update user/docs command listings to include the new command
- complete and close the issue 29 work item

## Validation
- 
pm run -w mdxtab test (6/6 passing)
- 
pm run -w mdxtab build (passing)

Closes #29