### PR TITLE
Pivot tables: add schema and frontmatter validation

### DIFF
--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -1,9 +1,9 @@
 # Work Item: Pivot Tables
 
 ## Status
-- State: PROPOSED
+- State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-tables` (umbrella only)
+- Branch: `issue-38-pivot-schema-validation` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -108,13 +108,13 @@ synthetically (same model as `report_tables`).
 ## Tasks
 
 ### 1. Design the `pivot_tables` frontmatter schema
-- [ ] Add `pivot_tables` to frontmatter types.
-- [ ] Required fields: `source`, `rows`, `columns`, `value`.
-- [ ] Optional fields: `empty_cells`, `totals`, `key`.
-- [ ] Validate name uniqueness against `tables` and `report_tables`.
-- [ ] Validate `source` references an authored table; `rows.from` and
+- [x] Add `pivot_tables` to frontmatter types.
+- [x] Required fields: `source`, `rows`, `columns`, `value`.
+- [x] Optional fields: `empty_cells`, `totals`, `key`.
+- [x] Validate name uniqueness against `tables` and `report_tables`.
+- [x] Validate `source` references an authored table; `rows.from` and
       `columns.from` reference real columns or table.column paths.
-- [ ] Diagnostics for missing/invalid fields, unknown identifiers, unsupported
+- [x] Diagnostics for missing/invalid fields, unknown identifiers, unsupported
       `step`, invalid date ranges (`start > end`, non-ISO dates).
 
 ### 2. Define column-axis generation
@@ -165,7 +165,7 @@ synthetically (same model as `report_tables`).
 - [ ] Unit: row/column totals (including running sum).
 - [ ] Integration: full compile + render of a `category × date` pivot matching
       the motivating user file.
-- [ ] Diagnostics: missing source, invalid range, unknown columns, identifier
+- [x] Diagnostics: missing source, invalid range, unknown columns, identifier
       collisions.
 
 ### 9. Docs & spec
@@ -186,6 +186,7 @@ synthetically (same model as `report_tables`).
 - Scope: frontmatter shape, parser validation, and diagnostics.
 - Includes tasks: 1
 - Stretch in same PR if small: diagnostic tests from task 8.
+- Progress: completed in commit `9252d56`.
 
 ### 2) Axes + cell evaluation + totals
 - Branch: `issue-38-pivot-eval-core`

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -982,6 +982,7 @@ pivot_tables:
     const result = validateMdxtab(badPivotDoc);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].column).toBe("totals.column.accumulated.mode");
     expect(result.diagnostics[0].message).toContain("totals.column.accumulated.mode must be one of sum, running_sum");
   });
 

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -814,7 +814,7 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("rows.from references unknown column");
   });
 
-  it("returns frontmatter diagnostics for invalid pivot_tables range", () => {
+  it("returns frontmatter diagnostics when pivot_tables range start is after end", () => {
     const badPivotDoc = `---
 mdxtab: "1.0"
 tables:
@@ -831,7 +831,7 @@ pivot_tables:
       range:
         start: 2026-05-24
         end: 2026-04-24
-        step: quarter
+        step: day
     value: sum(amount)
 ---
 
@@ -845,6 +845,39 @@ pivot_tables:
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
     expect(result.diagnostics[0].message).toContain("start must be before or equal");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables range step", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: quarter
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.step must be one of day, week, month");
   });
 
   it("accepts pivot_tables date ranges with years below 0100", () => {

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -720,6 +720,44 @@ pivot_tables:
     expect(result.frontmatter.pivot_tables?.liquidity.columns.range?.start).toBe("2026-04-24");
   });
 
+  it("normalizes pivot_tables rows.from and columns.from after validation", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: "  category  "
+    columns:
+      from: "  entries . date  "
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.frontmatter.pivot_tables?.liquidity.rows.from).toBe("category");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.from).toBe("date");
+  });
+
   it("returns frontmatter diagnostics when pivot_tables is missing required fields", () => {
     const badPivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -880,6 +880,177 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("columns.range.step must be one of day, week, month");
   });
 
+  it("returns frontmatter diagnostics for invalid pivot_tables empty_cells", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+    empty_cells: nope
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("Invalid empty_cells value");
+  });
+
+  it("returns frontmatter diagnostics for pivot_tables key not in source columns", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    key: missing_key
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("key missing_key is not a column");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables totals.column mode", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+    totals:
+      column:
+        accumulated:
+          mode: rolling
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("totals.column.accumulated.mode must be one of sum, running_sum");
+  });
+
+  it("returns frontmatter diagnostics for non-ISO pivot_tables range start", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-4-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.start must be an ISO date");
+  });
+
+  it("returns frontmatter diagnostics for non-ISO pivot_tables range end", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-5-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.end must be an ISO date");
+  });
+
   it("accepts pivot_tables date ranges with years below 0100", () => {
     const pivotDoc = `---
 mdxtab: "1.0"
@@ -909,6 +1080,45 @@ pivot_tables:
 
     const result = validateMdxtab(pivotDoc);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not fail when a manual markdown table exists under a pivot heading", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+
+## liquidity
+| stale | old |
+|-------|-----|
+| 1     | 2   |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.rendered).toContain("## liquidity");
   });
 
   it("does not remove prose after an existing report table when the prose contains pipes", () => {

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -680,6 +680,135 @@ report_tables:
     expect(result.rendered).toContain("## __proto__\n\n| label |");
   });
 
+  it("parses pivot_tables with required fields", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.frontmatter.pivot_tables?.liquidity.source).toBe("entries");
+    expect(result.frontmatter.pivot_tables?.liquidity.rows.from).toBe("category");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.from).toBe("date");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.range?.start).toBe("2026-04-24");
+  });
+
+  it("returns frontmatter diagnostics when pivot_tables is missing required fields", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    columns:
+      from: date
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("rows is required");
+  });
+
+  it("returns frontmatter diagnostics when pivot_tables source or axis references are invalid", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: missing_col
+    columns:
+      from: date
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("rows.from references unknown column");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables range", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-05-24
+        end: 2026-04-24
+        step: quarter
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("start must be before or equal");
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -847,6 +847,37 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("start must be before or equal");
   });
 
+  it("accepts pivot_tables date ranges with years below 0100", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 0099-01-01
+        end: 0099-01-02
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(pivotDoc);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -972,10 +972,11 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
 
   const schemaNames = new Set(Object.keys(frontmatter.tables));
   const reportTableNames = new Set(Object.keys(frontmatter.report_tables ?? {}));
+  const pivotTableNames = new Set(Object.keys(frontmatter.pivot_tables ?? {}));
   const tableByName = Object.create(null) as Record<string, ParsedTable>;
   for (const t of tables) {
     if (!schemaNames.has(t.name)) {
-      if (reportTableNames.has(t.name)) {
+      if (reportTableNames.has(t.name) || pivotTableNames.has(t.name)) {
         continue;
       }
       throw new DiagnosticError({

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -1,6 +1,14 @@
 import { parse as parseYaml } from "yaml";
 import { DiagnosticError, lineRange } from "./diagnostics.js";
-import type { FrontmatterDocument, ReportTableDefinition, SummaryRowDefinition, TableFrontmatter } from "./types.js";
+import type {
+  FrontmatterDocument,
+  PivotTableDefinition,
+  ReportTableDefinition,
+  SummaryRowDefinition,
+  TableFrontmatter,
+} from "./types.js";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function expectObject(value: unknown, context: string): Record<string, unknown> {
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -150,6 +158,286 @@ function parseReportTables(
   return result;
 }
 
+function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_RE.test(value)) return false;
+  const [yearRaw, monthRaw, dayRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year
+    && date.getUTCMonth() === month - 1
+    && date.getUTCDate() === day
+  );
+}
+
+function parsePivotTables(
+  value: unknown,
+  tables: Record<string, TableFrontmatter>,
+  reportTables: Record<string, ReportTableDefinition>,
+): Record<string, PivotTableDefinition> {
+  const obj = expectObject(value, "pivot_tables");
+  const result = Object.create(null) as Record<string, PivotTableDefinition>;
+  const hasOwnTable = (name: string): name is keyof typeof tables =>
+    Object.prototype.hasOwnProperty.call(tables, name);
+  const hasOwnReportTable = (name: string): boolean =>
+    Object.prototype.hasOwnProperty.call(reportTables, name);
+  const pivotTableError = (name: string, message: string, column?: string): DiagnosticError =>
+    new DiagnosticError({ code: "E_FRONTMATTER", message, table: name, column, range: lineRange(0) });
+
+  const expectPivotObject = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectObject(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const expectPivotString = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectString(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const expectPivotStringArray = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectStringArray(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const validateColumnReference = (
+    pivotName: string,
+    sourceTableName: string,
+    reference: string,
+    columnLabel: "rows.from" | "columns.from",
+  ) => {
+    const ref = reference.trim();
+    if (ref.length === 0) {
+      throw pivotTableError(pivotName, `pivot_table ${pivotName} ${columnLabel} must not be empty`, columnLabel);
+    }
+
+    let tableName = sourceTableName;
+    let columnName = ref;
+    if (ref.includes(".")) {
+      const parts = ref.split(".");
+      if (parts.length !== 2 || parts[0].trim().length === 0 || parts[1].trim().length === 0) {
+        throw pivotTableError(
+          pivotName,
+          `pivot_table ${pivotName} ${columnLabel} must be a column name or table.column reference`,
+          columnLabel,
+        );
+      }
+      tableName = parts[0].trim();
+      columnName = parts[1].trim();
+    }
+
+    if (!hasOwnTable(tableName)) {
+      throw pivotTableError(
+        pivotName,
+        `pivot_table ${pivotName} ${columnLabel} references unknown table ${tableName}`,
+        columnLabel,
+      );
+    }
+    if (!tables[tableName].columns.includes(columnName)) {
+      throw pivotTableError(
+        pivotName,
+        `pivot_table ${pivotName} ${columnLabel} references unknown column ${columnName} in table ${tableName}`,
+        columnLabel,
+      );
+    }
+  };
+
+  for (const [name, pivotValue] of Object.entries(obj)) {
+    if (hasOwnTable(name)) {
+      throw pivotTableError(name, `pivot_tables.${name} conflicts with table ${name}`);
+    }
+    if (hasOwnReportTable(name)) {
+      throw pivotTableError(name, `pivot_tables.${name} conflicts with report_table ${name}`);
+    }
+
+    const pivotObj = expectPivotObject(name, pivotValue, `pivot_table ${name}`);
+    const source = expectPivotString(name, pivotObj.source, `source for pivot_table ${name}`, "source");
+    if (!hasOwnTable(source)) {
+      throw pivotTableError(name, `pivot_table ${name} references unknown source table ${source}`, "source");
+    }
+    const sourceTable = tables[source];
+
+    if (pivotObj.rows === undefined) {
+      throw pivotTableError(name, `pivot_table ${name}: rows is required`, "rows");
+    }
+    const rowsObj = expectPivotObject(name, pivotObj.rows, `rows for pivot_table ${name}`, "rows");
+    const rowsFrom = expectPivotString(name, rowsObj.from, `rows.from for pivot_table ${name}`, "rows.from");
+    validateColumnReference(name, source, rowsFrom, "rows.from");
+    const rowsOrder = rowsObj.order === undefined
+      ? undefined
+      : expectPivotStringArray(name, rowsObj.order, `rows.order for pivot_table ${name}`, "rows.order");
+
+    if (pivotObj.columns === undefined) {
+      throw pivotTableError(name, `pivot_table ${name}: columns is required`, "columns");
+    }
+    const columnsObj = expectPivotObject(name, pivotObj.columns, `columns for pivot_table ${name}`, "columns");
+    const columnsFrom = expectPivotString(
+      name,
+      columnsObj.from,
+      `columns.from for pivot_table ${name}`,
+      "columns.from",
+    );
+    validateColumnReference(name, source, columnsFrom, "columns.from");
+
+    const columnsLabel = columnsObj.label === undefined
+      ? undefined
+      : expectPivotString(name, columnsObj.label, `columns.label for pivot_table ${name}`, "columns.label");
+
+    let columnsRange: PivotTableDefinition["columns"]["range"];
+    if (columnsObj.range !== undefined) {
+      const rangeObj = expectPivotObject(name, columnsObj.range, `columns.range for pivot_table ${name}`, "columns.range");
+      const start = expectPivotString(
+        name,
+        rangeObj.start,
+        `columns.range.start for pivot_table ${name}`,
+        "columns.range.start",
+      );
+      const end = expectPivotString(
+        name,
+        rangeObj.end,
+        `columns.range.end for pivot_table ${name}`,
+        "columns.range.end",
+      );
+
+      if (!isValidIsoDate(start)) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.start must be an ISO date (YYYY-MM-DD)`,
+          "columns.range.start",
+        );
+      }
+      if (!isValidIsoDate(end)) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.end must be an ISO date (YYYY-MM-DD)`,
+          "columns.range.end",
+        );
+      }
+      if (start > end) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.start must be before or equal to columns.range.end`,
+          "columns.range",
+        );
+      }
+
+      if (
+        rangeObj.step !== undefined
+        && rangeObj.step !== "day"
+        && rangeObj.step !== "week"
+        && rangeObj.step !== "month"
+      ) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.step must be one of day, week, month`,
+          "columns.range.step",
+        );
+      }
+
+      columnsRange = {
+        start,
+        end,
+        step: rangeObj.step,
+      };
+    }
+
+    const valueExpr = expectPivotString(name, pivotObj.value, `value for pivot_table ${name}`, "value");
+    const key = pivotObj.key === undefined
+      ? sourceTable.key ?? "id"
+      : expectPivotString(name, pivotObj.key, `key for pivot_table ${name}`, "key");
+    if (!sourceTable.columns.includes(key)) {
+      throw pivotTableError(name, `pivot_table ${name} key ${key} is not a column in source table ${source}`, "key");
+    }
+
+    if (
+      pivotObj.empty_cells !== undefined
+      && pivotObj.empty_cells !== "null"
+      && pivotObj.empty_cells !== "zero"
+      && pivotObj.empty_cells !== "empty-string"
+      && pivotObj.empty_cells !== "error"
+    ) {
+      throw pivotTableError(
+        name,
+        `Invalid empty_cells value for pivot_table ${name}: ${String(pivotObj.empty_cells)}`,
+        "empty_cells",
+      );
+    }
+
+    let totals: PivotTableDefinition["totals"];
+    if (pivotObj.totals !== undefined) {
+      const totalsObj = expectPivotObject(name, pivotObj.totals, `totals for pivot_table ${name}`, "totals");
+      const totalsRow = totalsObj.row === undefined
+        ? undefined
+        : expectPivotString(name, totalsObj.row, `totals.row for pivot_table ${name}`, "totals.row");
+
+      let totalsColumn: NonNullable<NonNullable<PivotTableDefinition["totals"]>["column"]> | undefined;
+      if (totalsObj.column !== undefined) {
+        const columnObj = expectPivotObject(name, totalsObj.column, `totals.column for pivot_table ${name}`, "totals.column");
+        const parsedTotalsColumn = Object.create(null) as NonNullable<NonNullable<PivotTableDefinition["totals"]>["column"]>;
+        for (const [footerName, footerValue] of Object.entries(columnObj)) {
+          const footerObj = expectPivotObject(
+            name,
+            footerValue,
+            `totals.column.${footerName} for pivot_table ${name}`,
+            "totals.column",
+          );
+          if (
+            footerObj.mode !== undefined
+            && footerObj.mode !== "sum"
+            && footerObj.mode !== "running_sum"
+          ) {
+            throw pivotTableError(
+              name,
+              `pivot_table ${name} totals.column.${footerName}.mode must be one of sum, running_sum`,
+              "totals.column",
+            );
+          }
+          parsedTotalsColumn[footerName] = { mode: footerObj.mode as "sum" | "running_sum" | undefined };
+        }
+        totalsColumn = parsedTotalsColumn;
+      }
+
+      totals = {
+        row: totalsRow,
+        column: totalsColumn,
+      };
+    }
+
+    result[name] = {
+      source,
+      key,
+      rows: {
+        from: rowsFrom,
+        order: rowsOrder,
+      },
+      columns: {
+        from: columnsFrom,
+        range: columnsRange,
+        label: columnsLabel,
+      },
+      value: valueExpr,
+      empty_cells: pivotObj.empty_cells,
+      totals,
+    };
+  }
+
+  return result;
+}
+
 function validateTable(name: string, value: unknown): TableFrontmatter {
   const obj = expectObject(value, `table ${name}`);
   const columns = expectStringArray(obj.columns, `columns for table ${name}`);
@@ -236,8 +524,11 @@ export function parseFrontmatter(raw: string): FrontmatterDocument {
     const report_tables = obj.report_tables
       ? parseReportTables(obj.report_tables, tables)
       : undefined;
+    const pivot_tables = obj.pivot_tables
+      ? parsePivotTables(obj.pivot_tables, tables, report_tables ?? Object.create(null))
+      : undefined;
 
-    return { mdxtab, tables, report_tables };
+    return { mdxtab, tables, report_tables, pivot_tables };
   } catch (err) {
     if (err instanceof DiagnosticError) throw err;
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -165,12 +165,13 @@ function isValidIsoDate(value: string): boolean {
   const month = Number(monthRaw);
   const day = Number(dayRaw);
   if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
-  const date = new Date(Date.UTC(year, month - 1, day));
-  return (
-    date.getUTCFullYear() === year
-    && date.getUTCMonth() === month - 1
-    && date.getUTCDate() === day
-  );
+
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
 }
 
 function parsePivotTables(

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -219,7 +219,7 @@ function parsePivotTables(
     sourceTableName: string,
     reference: string,
     columnLabel: "rows.from" | "columns.from",
-  ) => {
+  ): string => {
     const ref = reference.trim();
     if (ref.length === 0) {
       throw pivotTableError(pivotName, `pivot_table ${pivotName} ${columnLabel} must not be empty`, columnLabel);
@@ -254,6 +254,8 @@ function parsePivotTables(
         columnLabel,
       );
     }
+
+    return tableName === sourceTableName ? columnName : `${tableName}.${columnName}`;
   };
 
   for (const [name, pivotValue] of Object.entries(obj)) {
@@ -275,8 +277,8 @@ function parsePivotTables(
       throw pivotTableError(name, `pivot_table ${name}: rows is required`, "rows");
     }
     const rowsObj = expectPivotObject(name, pivotObj.rows, `rows for pivot_table ${name}`, "rows");
-    const rowsFrom = expectPivotString(name, rowsObj.from, `rows.from for pivot_table ${name}`, "rows.from");
-    validateColumnReference(name, source, rowsFrom, "rows.from");
+    const rowsFromRaw = expectPivotString(name, rowsObj.from, `rows.from for pivot_table ${name}`, "rows.from");
+    const rowsFrom = validateColumnReference(name, source, rowsFromRaw, "rows.from");
     const rowsOrder = rowsObj.order === undefined
       ? undefined
       : expectPivotStringArray(name, rowsObj.order, `rows.order for pivot_table ${name}`, "rows.order");
@@ -291,7 +293,7 @@ function parsePivotTables(
       `columns.from for pivot_table ${name}`,
       "columns.from",
     );
-    validateColumnReference(name, source, columnsFrom, "columns.from");
+    const normalizedColumnsFrom = validateColumnReference(name, source, columnsFrom, "columns.from");
 
     const columnsLabel = columnsObj.label === undefined
       ? undefined
@@ -425,7 +427,7 @@ function parsePivotTables(
         order: rowsOrder,
       },
       columns: {
-        from: columnsFrom,
+        from: normalizedColumnsFrom,
         range: columnsRange,
         label: columnsLabel,
       },

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -392,11 +392,12 @@ function parsePivotTables(
         const columnObj = expectPivotObject(name, totalsObj.column, `totals.column for pivot_table ${name}`, "totals.column");
         const parsedTotalsColumn = Object.create(null) as NonNullable<NonNullable<PivotTableDefinition["totals"]>["column"]>;
         for (const [footerName, footerValue] of Object.entries(columnObj)) {
+          const footerPath = `totals.column.${footerName}`;
           const footerObj = expectPivotObject(
             name,
             footerValue,
-            `totals.column.${footerName} for pivot_table ${name}`,
-            "totals.column",
+            `${footerPath} for pivot_table ${name}`,
+            footerPath,
           );
           if (
             footerObj.mode !== undefined
@@ -406,7 +407,7 @@ function parsePivotTables(
             throw pivotTableError(
               name,
               `pivot_table ${name} totals.column.${footerName}.mode must be one of sum, running_sum`,
-              "totals.column",
+              `${footerPath}.mode`,
             );
           }
           parsedTotalsColumn[footerName] = { mode: footerObj.mode as "sum" | "running_sum" | undefined };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,42 @@ export interface ReportTableDefinition {
   cells: Record<string, string>;
 }
 
+export interface PivotRowsDefinition {
+  from: string;
+  order?: string[];
+}
+
+export interface PivotColumnsRangeDefinition {
+  start: string;
+  end: string;
+  step?: "day" | "week" | "month";
+}
+
+export interface PivotColumnsDefinition {
+  from: string;
+  range?: PivotColumnsRangeDefinition;
+  label?: string;
+}
+
+export interface PivotTotalsColumnModeDefinition {
+  mode?: "sum" | "running_sum";
+}
+
+export interface PivotTotalsDefinition {
+  row?: string;
+  column?: Record<string, PivotTotalsColumnModeDefinition>;
+}
+
+export interface PivotTableDefinition {
+  source: string;
+  rows: PivotRowsDefinition;
+  columns: PivotColumnsDefinition;
+  value: string;
+  key?: string;
+  empty_cells?: "null" | "zero" | "empty-string" | "error";
+  totals?: PivotTotalsDefinition;
+}
+
 export interface TableFrontmatter {
   key?: string;
   columns: string[];
@@ -41,6 +77,7 @@ export interface FrontmatterDocument {
   mdxtab: string;
   tables: Record<string, TableFrontmatter>;
   report_tables?: Record<string, ReportTableDefinition>;
+  pivot_tables?: Record<string, PivotTableDefinition>;
 }
 
 export interface HeaderCell {


### PR DESCRIPTION
## Summary
- add pivot_tables type definitions to core frontmatter model
- parse and validate pivot_tables in frontmatter parser
- validate required fields, source/axis references, range and step constraints
- add diagnostics-focused tests for pivot_tables schema errors
- update work-item checklist status for sub-branch 1

## Validation
- npm run -w @mdxtab/core build
- npm run -w @mdxtab/core test

Refs #38