### PR TITLE
Pivot tables: evaluate axes, cells, and totals

### DIFF
--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-schema-validation` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-eval-core` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -118,33 +118,33 @@ synthetically (same model as `report_tables`).
       `step`, invalid date ranges (`start > end`, non-ISO dates).
 
 ### 2. Define column-axis generation
-- [ ] Derive the ordered axis from either:
+- [x] Derive the ordered axis from either:
   - distinct source-column values (sorted deterministically), or
   - a `range` over `date` with `step`.
-- [ ] Generate stable header identifiers (must satisfy identifier rules so
+- [x] Generate stable header identifiers (must satisfy identifier rules so
       they can be referenced by `totals` and downstream lookups).
-- [ ] Surface header derivation in compile output for tooling.
+- [x] Surface header derivation in compile output for tooling.
 
 ### 3. Define row-axis generation
-- [ ] Derive the ordered row list from distinct source values, or from a
+- [x] Derive the ordered row list from distinct source values, or from a
       referenced table column when `rows.from: <table>.<col>` is used.
-- [ ] Preserve declared order when sourced from a table; sort deterministically
+- [x] Preserve declared order when sourced from a table; sort deterministically
       otherwise.
 
 ### 4. Evaluate pivot cells
-- [ ] For each (row, column) pair, evaluate `value` over the subset of
+- [x] For each (row, column) pair, evaluate `value` over the subset of
       `source` rows matching that row key and column-axis value.
-- [ ] Apply `empty_cells` policy when no events match.
-- [ ] Reuse the existing aggregate evaluator; no new functions required for
+- [x] Apply `empty_cells` policy when no events match.
+- [x] Reuse the existing aggregate evaluator; no new functions required for
       MVP (`sum` only).
-- [ ] Define error behavior consistent with `report_tables` (missing source,
+- [x] Define error behavior consistent with `report_tables` (missing source,
       type mismatch on axis values, etc.).
 
 ### 5. Totals
-- [ ] `totals.row: <name>` adds a synthesized trailing column equal to
+- [x] `totals.row: <name>` adds a synthesized trailing column equal to
       `sum` across the row's pivot cells.
-- [ ] `totals.column.<name>.mode: sum | running_sum` adds a footer row.
-- [ ] Names must satisfy identifier rules and not collide with axis headers.
+- [x] `totals.column.<name>.mode: sum | running_sum` adds a footer row.
+- [x] Names must satisfy identifier rules and not collide with axis headers.
 
 ### 6. Render injection
 - [ ] Detect `## <pivot_name>` headings and inject the rendered Markdown
@@ -160,10 +160,10 @@ synthetically (same model as `report_tables`).
       table (deferred: pivot output is not addressable in expressions in MVP).
 
 ### 8. Tests
-- [ ] Unit: axis generation (distinct values, date range, deterministic order).
-- [ ] Unit: cell evaluation with `empty_cells` policies.
-- [ ] Unit: row/column totals (including running sum).
-- [ ] Integration: full compile + render of a `category × date` pivot matching
+- [x] Unit: axis generation (distinct values, date range, deterministic order).
+- [x] Unit: cell evaluation with `empty_cells` policies.
+- [x] Unit: row/column totals (including running sum).
+- [x] Integration: full compile + render of a `category × date` pivot matching
       the motivating user file.
 - [x] Diagnostics: missing source, invalid range, unknown columns, identifier
       collisions.
@@ -193,6 +193,7 @@ synthetically (same model as `report_tables`).
 - Scope: row/column axis generation, cell aggregation, totals behavior.
 - Includes tasks: 2, 3, 4, 5
 - Tests in same PR: unit tests for axis/cell/totals from task 8.
+- Progress: completed in commit `8e2fa0c`.
 
 ### 3) Pipeline + rendering
 - Branch: `issue-38-pivot-render-pipeline`
@@ -214,7 +215,7 @@ synthetically (same model as `report_tables`).
 
 ### Notes
 - Keep `issue-38-pivot-tables` as umbrella tracking branch only.
-- Open each PR against `main` to keep review scope focused and parallelizable.
+- Open each sub-branch PR against `issue-38-pivot-tables` for staged integration.
 
 ## Out of scope (v1 of this work item)
 - Multiple aggregators per cell.

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1122,6 +1122,117 @@ pivot_tables:
     expect(result.rendered).toContain("## liquidity");
   });
 
+  it("evaluates pivot tables with range columns, row totals, and running footer", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+      order: [Salary, Food]
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-25
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+    totals:
+      row: summary
+      column:
+        accumulated:
+          mode: running_sum
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Salary | 50 |
+| e3 | 2026-04-25 | Food | -30 |
+| e4 | 2026-04-25 | Salary | 20 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+
+    expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Salary", "Food"]);
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
+
+    expect(pivot.rows[0].values["2026-04-24"]).toBe(150);
+    expect(pivot.rows[0].values["2026-04-25"]).toBe(20);
+    expect(pivot.rows[0].total).toBe(170);
+
+    expect(pivot.rows[1].values["2026-04-24"]).toBe(0);
+    expect(pivot.rows[1].values["2026-04-25"]).toBe(-30);
+    expect(pivot.rows[1].total).toBe(-30);
+
+    expect(pivot.footerRows?.[0].key).toBe("accumulated");
+    expect(pivot.footerRows?.[0].values["2026-04-24"]).toBe(150);
+    expect(pivot.footerRows?.[0].values["2026-04-25"]).toBe(140);
+    expect(pivot.footerRows?.[0].total).toBe(290);
+  });
+
+  it("derives pivot row axis from another table in authored order", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  categories:
+    key: id
+    columns: [id, category]
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: categories.category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-24
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## categories
+| id | category |
+|----|----------|
+| c1 | Travel |
+| c2 | Salary |
+| c3 | Food |
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Food | -30 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+
+    expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Travel", "Salary", "Food"]);
+    expect(pivot.rows[0].values["2026-04-24"]).toBe(0);
+    expect(pivot.rows[1].values["2026-04-24"]).toBe(100);
+    expect(pivot.rows[2].values["2026-04-24"]).toBe(-30);
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1320,6 +1320,56 @@ pivot_tables:
     expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
   });
 
+  it("generates identifier-safe, unique pivot axis ids", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-26
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Food | -30 |
+| e3 | 2026-04-26 | Travel Expense | -10 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const axisIdRe = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+    for (const entry of pivot.rowAxis) {
+      expect(entry.id).toMatch(axisIdRe);
+    }
+    for (const entry of pivot.columnAxis) {
+      expect(entry.id).toMatch(axisIdRe);
+    }
+
+    const rowIdSet = new Set(pivot.rowAxis.map((entry) => entry.id));
+    const colIdSet = new Set(pivot.columnAxis.map((entry) => entry.id));
+    expect(rowIdSet.size).toBe(pivot.rowAxis.length);
+    expect(colIdSet.size).toBe(pivot.columnAxis.length);
+  });
+
   it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1164,21 +1164,23 @@ pivot_tables:
 
     const result = compileMdxtab(pivotDoc);
     const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+    const c1 = pivot.columnAxis[1].id;
 
     expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Salary", "Food"]);
     expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
 
-    expect(pivot.rows[0].values["2026-04-24"]).toBe(150);
-    expect(pivot.rows[0].values["2026-04-25"]).toBe(20);
+    expect(pivot.rows[0].values[c0]).toBe(150);
+    expect(pivot.rows[0].values[c1]).toBe(20);
     expect(pivot.rows[0].total).toBe(170);
 
-    expect(pivot.rows[1].values["2026-04-24"]).toBe(0);
-    expect(pivot.rows[1].values["2026-04-25"]).toBe(-30);
+    expect(pivot.rows[1].values[c0]).toBe(0);
+    expect(pivot.rows[1].values[c1]).toBe(-30);
     expect(pivot.rows[1].total).toBe(-30);
 
     expect(pivot.footerRows?.[0].key).toBe("accumulated");
-    expect(pivot.footerRows?.[0].values["2026-04-24"]).toBe(150);
-    expect(pivot.footerRows?.[0].values["2026-04-25"]).toBe(140);
+    expect(pivot.footerRows?.[0].values[c0]).toBe(150);
+    expect(pivot.footerRows?.[0].values[c1]).toBe(140);
     expect(pivot.footerRows?.[0].total).toBe(290);
   });
 
@@ -1226,11 +1228,12 @@ pivot_tables:
 
     const result = compileMdxtab(pivotDoc);
     const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
 
     expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Travel", "Salary", "Food"]);
-    expect(pivot.rows[0].values["2026-04-24"]).toBe(0);
-    expect(pivot.rows[1].values["2026-04-24"]).toBe(100);
-    expect(pivot.rows[2].values["2026-04-24"]).toBe(-30);
+    expect(pivot.rows[0].values[c0]).toBe(0);
+    expect(pivot.rows[1].values[c0]).toBe(100);
+    expect(pivot.rows[2].values[c0]).toBe(-30);
   });
 
   it("generates month-stepped pivot columns with clamped month-end progression", () => {
@@ -1268,11 +1271,14 @@ pivot_tables:
 
     const result = compileMdxtab(pivotDoc);
     const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+    const c1 = pivot.columnAxis[1].id;
+    const c2 = pivot.columnAxis[2].id;
 
     expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-01-31", "2026-02-28", "2026-03-28"]);
-    expect(pivot.rows[0].values["2026-01-31"]).toBe(100);
-    expect(pivot.rows[0].values["2026-02-28"]).toBe(110);
-    expect(pivot.rows[0].values["2026-03-28"]).toBe(120);
+    expect(pivot.rows[0].values[c0]).toBe(100);
+    expect(pivot.rows[0].values[c1]).toBe(110);
+    expect(pivot.rows[0].values[c2]).toBe(120);
   });
 
   it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1233,6 +1233,51 @@ pivot_tables:
     expect(pivot.rows[2].values["2026-04-24"]).toBe(-30);
   });
 
+  it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  categories:
+    key: id
+    columns: [id, category]
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: categories.category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-24
+        step: day
+    value: sum(amount)
+    empty_cells: error
+---
+
+## categories
+| id | category |
+|----|----------|
+| c1 | Travel |
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(pivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_EMPTY_CELL");
+    expect(result.diagnostics[0].table).toBe("liquidity");
+    expect(result.diagnostics[0].column).toBe("empty_cells");
+    expect(result.diagnostics[0].rowKey).toBe("Travel");
+    expect(result.diagnostics[0].message).toContain("[pivot-table]");
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1320,6 +1320,37 @@ pivot_tables:
     expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
   });
 
+  it("throws when short_month_day receives a calendar-invalid ISO date key", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-13-10 | Salary | 100 |
+`;
+
+    expect(() => compileMdxtab(pivotDoc)).toThrow(/short_month_day requires ISO date keys/);
+  });
+
   it("generates identifier-safe, unique pivot axis ids", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1281,6 +1281,45 @@ pivot_tables:
     expect(pivot.rows[0].values[c2]).toBe(120);
   });
 
+  it("applies pivot.columns.label when generating column axis labels", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+      range:
+        start: 2026-04-24
+        end: 2026-04-25
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Salary | 200 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
+    expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
+  });
+
   it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1233,6 +1233,48 @@ pivot_tables:
     expect(pivot.rows[2].values["2026-04-24"]).toBe(-30);
   });
 
+  it("generates month-stepped pivot columns with clamped month-end progression", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-01-31
+        end: 2026-03-31
+        step: month
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-01-31 | Salary | 100 |
+| e2 | 2026-02-28 | Salary | 110 |
+| e3 | 2026-03-28 | Salary | 120 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-01-31", "2026-02-28", "2026-03-28"]);
+    expect(pivot.rows[0].values["2026-01-31"]).toBe(100);
+    expect(pivot.rows[0].values["2026-02-28"]).toBe(110);
+    expect(pivot.rows[0].values["2026-03-28"]).toBe(120);
+  });
+
   it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -946,6 +946,21 @@ function parseIsoDatePreserveYear(isoDate: string): Date {
   return date;
 }
 
+function isValidIsoDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const [yearText, monthText, dayText] = value.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
 function formatIsoDate(date: Date): string {
   const year = String(date.getUTCFullYear()).padStart(4, "0");
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
@@ -982,7 +997,7 @@ function derivePivotColumnLabel(
   if (!labelMode || labelMode === "iso_date") return raw;
 
   if (labelMode === "short_month_day") {
-    if (!DATE_RE.test(raw)) {
+    if (!isValidIsoDate(raw)) {
       throw new DiagnosticError({
         code: "E_FRONTMATTER",
         message: `pivot_table ${pivotName} columns.label short_month_day requires ISO date keys`,

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1089,6 +1089,7 @@ function evaluatePivotTables(
 
     const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
     const pairValueBuckets = new Map<string, Scalar[]>();
+    const pairDisplayKeys = new Map<string, { row: string; column: string }>();
     const pairKey = (rowKey: Scalar, columnKey: Scalar) =>
       JSON.stringify([scalarIdentity(rowKey), scalarIdentity(columnKey)]);
 
@@ -1104,6 +1105,7 @@ function evaluatePivotTables(
         bucket.push(row[valueColumn]);
       } else {
         pairValueBuckets.set(key, [row[valueColumn]]);
+        pairDisplayKeys.set(key, { row: String(rowKey), column: String(colKey) });
       }
     }
 
@@ -1112,12 +1114,12 @@ function evaluatePivotTables(
       try {
         pairAggregates.set(key, computeAggregateValues("sum", values));
       } catch (err) {
-        const [rowKeyRaw, columnKeyRaw] = JSON.parse(key) as [string, string];
+        const display = pairDisplayKeys.get(key) ?? { row: "<unknown>", column: "<unknown>" };
         throw toPivotDiagnostic(err, {
           table: name,
-          rowKey: rowKeyRaw,
-          column: columnKeyRaw,
-          messagePrefix: `[pivot-table] table ${name} cell row=${rowKeyRaw} column=${columnKeyRaw}`,
+          rowKey: display.row,
+          column: display.column,
+          messagePrefix: `[pivot-table] table ${name} cell row=${display.row} column=${display.column}`,
         });
       }
     }

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -840,11 +840,12 @@ function parseColumnReference(sourceTable: string, reference: string): { table: 
 }
 
 function uniqueByString(values: Scalar[]): Scalar[] {
+  const scalarKey = (value: Scalar) => `${value === null ? "null" : typeof value}:${String(value)}`;
   const seen = new Set<string>();
   const out: Scalar[] = [];
   for (const value of values) {
     if (value === null || value === undefined) continue;
-    const key = String(value);
+    const key = scalarKey(value);
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(value);
@@ -861,19 +862,21 @@ function compareByString(a: Scalar, b: Scalar): number {
 }
 
 function applyRowOrdering(values: Scalar[], order: string[] | undefined): Scalar[] {
+  const scalarKey = (value: Scalar) => `${value === null ? "null" : typeof value}:${String(value)}`;
   if (!order || order.length === 0) return values;
   const remaining = [...values];
-  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [String(value), value]));
+  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [scalarKey(value), value]));
   const ordered: Scalar[] = [];
 
-  for (const key of order) {
+  for (const orderedValue of order) {
+    const key = scalarKey(orderedValue);
     if (!remainingByKey.has(key)) continue;
     ordered.push(remainingByKey.get(key)!);
     remainingByKey.delete(key);
   }
 
   for (const value of remaining) {
-    const key = String(value);
+    const key = scalarKey(value);
     if (!remainingByKey.has(key)) continue;
     ordered.push(value);
     remainingByKey.delete(key);

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1143,10 +1143,13 @@ function evaluatePivotTables(
     }));
 
     const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
+    const rowAxisIdByIdentity = new Map<string, string>(rowAxis.map((entry) => [scalarIdentity(entry.key), entry.id]));
+    const columnAxisIdByIdentity = new Map<string, string>(
+      columnAxis.map((entry) => [scalarIdentity(entry.key), entry.id]),
+    );
     const pairValueBuckets = new Map<string, Scalar[]>();
     const pairDisplayKeys = new Map<string, { row: string; column: string }>();
-    const pairKey = (rowKey: Scalar, columnKey: Scalar) =>
-      JSON.stringify([scalarIdentity(rowKey), scalarIdentity(columnKey)]);
+    const pairKey = (rowId: string, columnId: string) => `${rowId}\u0000${columnId}`;
 
     for (const row of ensuredSourceRows) {
       const rowKey = row[rowRef.column];
@@ -1154,7 +1157,12 @@ function evaluatePivotTables(
       if (rowKey === null || rowKey === undefined || colKey === null || colKey === undefined) {
         continue;
       }
-      const key = pairKey(rowKey, colKey);
+      const rowId = rowAxisIdByIdentity.get(scalarIdentity(rowKey));
+      const columnId = columnAxisIdByIdentity.get(scalarIdentity(colKey));
+      if (!rowId || !columnId) {
+        continue;
+      }
+      const key = pairKey(rowId, columnId);
       const bucket = pairValueBuckets.get(key);
       if (bucket) {
         bucket.push(row[valueColumn]);
@@ -1183,7 +1191,7 @@ function evaluatePivotTables(
       const values = Object.create(null) as Record<string, Scalar>;
 
       for (const columnAxisEntry of columnAxis) {
-        const key = pairKey(rowAxisEntry.key, columnAxisEntry.key);
+        const key = pairKey(rowAxisEntry.id, columnAxisEntry.id);
         if (!pairValueBuckets.has(key)) {
           try {
             values[columnAxisEntry.id] = emptyPivotCell(pivot.empty_cells);

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -852,6 +852,14 @@ function uniqueByString(values: Scalar[]): Scalar[] {
   return out;
 }
 
+function compareByString(a: Scalar, b: Scalar): number {
+  const left = String(a);
+  const right = String(b);
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
 function applyRowOrdering(values: Scalar[], order: string[] | undefined): Scalar[] {
   if (!order || order.length === 0) return values;
   const remaining = [...values];
@@ -989,7 +997,7 @@ function evaluatePivotTables(
     const ensureRowAxisTable = ensureByTable[rowRef.table];
     let rowValues = uniqueByString(rowAxisSourceRows.map((row) => ensureRowAxisTable(row)[rowRef.column]));
     if (rowRef.table === pivot.source) {
-      rowValues = [...rowValues].sort((a, b) => String(a).localeCompare(String(b)));
+      rowValues = [...rowValues].sort(compareByString);
     }
     rowValues = applyRowOrdering(rowValues, pivot.rows.order);
 
@@ -1004,7 +1012,7 @@ function evaluatePivotTables(
       );
     } else {
       columnValues = uniqueByString(columnAxisSourceRows.map((row) => ensureColumnAxisTable(row)[columnRef.column]));
-      columnValues = [...columnValues].sort((a, b) => String(a).localeCompare(String(b)));
+      columnValues = [...columnValues].sort(compareByString);
     }
 
     const rowAxis = rowValues.map((key, index) => ({ key, label: String(key), index }));

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1084,8 +1084,8 @@ function evaluatePivotTables(
       columnValues = [...columnValues].sort(compareByString);
     }
 
-    const rowAxis = rowValues.map((key, index) => ({ key, label: String(key), index }));
-    const columnAxis = columnValues.map((key, index) => ({ key, label: String(key), index }));
+    const rowAxis = rowValues.map((key, index) => ({ id: scalarIdentity(key), key, label: String(key), index }));
+    const columnAxis = columnValues.map((key, index) => ({ id: scalarIdentity(key), key, label: String(key), index }));
 
     const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
     const pairValueBuckets = new Map<string, Scalar[]>();
@@ -1129,7 +1129,7 @@ function evaluatePivotTables(
         const key = pairKey(rowAxisEntry.key, columnAxisEntry.key);
         if (!pairValueBuckets.has(key)) {
           try {
-            values[columnAxisEntry.label] = emptyPivotCell(pivot.empty_cells);
+            values[columnAxisEntry.id] = emptyPivotCell(pivot.empty_cells);
           } catch (err) {
             throw toPivotDiagnostic(err, {
               table: name,
@@ -1140,7 +1140,7 @@ function evaluatePivotTables(
           }
           continue;
         }
-        values[columnAxisEntry.label] = pairAggregates.get(key) ?? 0;
+        values[columnAxisEntry.id] = pairAggregates.get(key) ?? 0;
       }
 
       const rowTotal = pivot.totals?.row
@@ -1164,15 +1164,15 @@ function evaluatePivotTables(
         for (const columnAxisEntry of columnAxis) {
           const colTotal = computeAggregateValues(
             "sum",
-            evaluatedRows.map((row) => toNumericOrNull(row.values[columnAxisEntry.label])),
+            evaluatedRows.map((row) => toNumericOrNull(row.values[columnAxisEntry.id])),
           );
 
           if (mode === "running_sum") {
             const numericColTotal = typeof colTotal === "number" ? colTotal : 0;
             running += numericColTotal;
-            footerValues[columnAxisEntry.label] = running;
+            footerValues[columnAxisEntry.id] = running;
           } else {
-            footerValues[columnAxisEntry.label] = colTotal;
+            footerValues[columnAxisEntry.id] = colTotal;
           }
         }
 

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -114,6 +114,23 @@ function scalarIdentity(value: Scalar): string {
   return `${typeof value}:${String(value)}`;
 }
 
+function stableHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function scalarIdentifier(value: Scalar): string {
+  const typeName = value === null ? "null" : typeof value;
+  let slug = String(value).replace(/[^A-Za-z0-9_]/g, "_");
+  if (slug.length === 0) slug = "_";
+  if (!/^[A-Za-z_]/.test(slug)) slug = `_${slug}`;
+  return `k_${typeName}_${slug}_${stableHash(scalarIdentity(value))}`;
+}
+
 function coerceValue(text: string, type: ColumnType): Scalar {
   if (text === "true" || text === "false") {
     if (!type || type === "bool") return text === "true";
@@ -1117,9 +1134,9 @@ function evaluatePivotTables(
       columnValues = [...columnValues].sort(compareByString);
     }
 
-    const rowAxis = rowValues.map((key, index) => ({ id: scalarIdentity(key), key, label: String(key), index }));
+    const rowAxis = rowValues.map((key, index) => ({ id: scalarIdentifier(key), key, label: String(key), index }));
     const columnAxis = columnValues.map((key, index) => ({
-      id: scalarIdentity(key),
+      id: scalarIdentifier(key),
       key,
       label: derivePivotColumnLabel(name, key, pivot.columns.label),
       index,

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -108,6 +108,11 @@ function splitFrontmatter(raw: string): { frontmatter: string; body: string; bod
   return { frontmatter, body, bodyOffset: endIndex + 1 };
 }
 
+function scalarIdentity(value: Scalar): string {
+  if (value === null) return "null:null";
+  return `${typeof value}:${String(value)}`;
+}
+
 function coerceValue(text: string, type: ColumnType): Scalar {
   if (text === "true" || text === "false") {
     if (!type || type === "bool") return text === "true";
@@ -840,12 +845,11 @@ function parseColumnReference(sourceTable: string, reference: string): { table: 
 }
 
 function uniqueByString(values: Scalar[]): Scalar[] {
-  const scalarKey = (value: Scalar) => `${value === null ? "null" : typeof value}:${String(value)}`;
   const seen = new Set<string>();
   const out: Scalar[] = [];
   for (const value of values) {
     if (value === null || value === undefined) continue;
-    const key = scalarKey(value);
+    const key = scalarIdentity(value);
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(value);
@@ -862,21 +866,20 @@ function compareByString(a: Scalar, b: Scalar): number {
 }
 
 function applyRowOrdering(values: Scalar[], order: string[] | undefined): Scalar[] {
-  const scalarKey = (value: Scalar) => `${value === null ? "null" : typeof value}:${String(value)}`;
   if (!order || order.length === 0) return values;
   const remaining = [...values];
-  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [scalarKey(value), value]));
+  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [scalarIdentity(value), value]));
   const ordered: Scalar[] = [];
 
   for (const orderedValue of order) {
-    const key = scalarKey(orderedValue);
+    const key = scalarIdentity(orderedValue);
     if (!remainingByKey.has(key)) continue;
     ordered.push(remainingByKey.get(key)!);
     remainingByKey.delete(key);
   }
 
   for (const value of remaining) {
-    const key = scalarKey(value);
+    const key = scalarIdentity(value);
     if (!remainingByKey.has(key)) continue;
     ordered.push(value);
     remainingByKey.delete(key);
@@ -932,6 +935,26 @@ function formatIsoDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function daysInUtcMonth(year: number, monthIndexZeroBased: number): number {
+  return new Date(Date.UTC(year, monthIndexZeroBased + 1, 0)).getUTCDate();
+}
+
+function addUtcMonthsClamped(date: Date, months: number): Date {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+
+  const rawTargetMonth = month + months;
+  const targetYear = year + Math.floor(rawTargetMonth / 12);
+  const targetMonth = ((rawTargetMonth % 12) + 12) % 12;
+  const clampedDay = Math.min(day, daysInUtcMonth(targetYear, targetMonth));
+
+  const next = new Date(Date.UTC(0, 0, 1));
+  next.setUTCFullYear(targetYear, targetMonth, clampedDay);
+  next.setUTCHours(0, 0, 0, 0);
+  return next;
+}
+
 function buildDateRangeValues(
   pivotName: string,
   start: string,
@@ -939,7 +962,7 @@ function buildDateRangeValues(
   step: "day" | "week" | "month",
 ): Scalar[] {
   const values: Scalar[] = [];
-  const current = parseIsoDatePreserveYear(start);
+  let current = parseIsoDatePreserveYear(start);
   const endDate = parseIsoDatePreserveYear(end);
 
   let guard = 0;
@@ -949,7 +972,7 @@ function buildDateRangeValues(
     const before = current.getTime();
     if (step === "day") current.setUTCDate(current.getUTCDate() + 1);
     else if (step === "week") current.setUTCDate(current.getUTCDate() + 7);
-    else current.setUTCMonth(current.getUTCMonth() + 1);
+    else current = addUtcMonthsClamped(current, 1);
 
     if (current.getTime() <= before) {
       throw new DiagnosticError({
@@ -1066,7 +1089,8 @@ function evaluatePivotTables(
 
     const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
     const pairValueBuckets = new Map<string, Scalar[]>();
-    const pairKey = (rowKey: Scalar, columnKey: Scalar) => `${String(rowKey)}\u0000${String(columnKey)}`;
+    const pairKey = (rowKey: Scalar, columnKey: Scalar) =>
+      JSON.stringify([scalarIdentity(rowKey), scalarIdentity(columnKey)]);
 
     for (const row of ensuredSourceRows) {
       const rowKey = row[rowRef.column];
@@ -1088,7 +1112,7 @@ function evaluatePivotTables(
       try {
         pairAggregates.set(key, computeAggregateValues("sum", values));
       } catch (err) {
-        const [rowKeyRaw, columnKeyRaw] = key.split("\u0000");
+        const [rowKeyRaw, columnKeyRaw] = JSON.parse(key) as [string, string];
         throw toPivotDiagnostic(err, {
           table: name,
           rowKey: rowKeyRaw,

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -929,7 +929,12 @@ function formatIsoDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function buildDateRangeValues(start: string, end: string, step: "day" | "week" | "month"): Scalar[] {
+function buildDateRangeValues(
+  pivotName: string,
+  start: string,
+  end: string,
+  step: "day" | "week" | "month",
+): Scalar[] {
   const values: Scalar[] = [];
   const current = parseIsoDatePreserveYear(start);
   const endDate = parseIsoDatePreserveYear(end);
@@ -944,11 +949,23 @@ function buildDateRangeValues(start: string, end: string, step: "day" | "week" |
     else current.setUTCMonth(current.getUTCMonth() + 1);
 
     if (current.getTime() <= before) {
-      throw new Error("E_RANGE: invalid pivot date range increment");
+      throw new DiagnosticError({
+        code: "E_RANGE",
+        message: `pivot_table ${pivotName} has invalid date range increment`,
+        table: pivotName,
+        column: "columns.range",
+        range: lineRange(0),
+      });
     }
     guard += 1;
     if (guard > 100000) {
-      throw new Error("E_LIMIT: pivot date range too large");
+      throw new DiagnosticError({
+        code: "E_LIMIT",
+        message: `pivot_table ${pivotName} date range is too large`,
+        table: pivotName,
+        column: "columns.range",
+        range: lineRange(0),
+      });
     }
   }
 
@@ -972,6 +989,31 @@ function emptyPivotCell(policy: PivotTableDefinition["empty_cells"] | undefined)
 
 function toNumericOrNull(value: Scalar): Scalar {
   return typeof value === "number" ? value : null;
+}
+
+function toPivotDiagnostic(
+  err: unknown,
+  info: { table: string; rowKey?: string; column?: string; messagePrefix: string },
+): DiagnosticError {
+  if (err instanceof DiagnosticError) {
+    return new DiagnosticError({
+      code: err.code,
+      message: `${info.messagePrefix}: ${err.message}`,
+      severity: err.severity,
+      table: err.table ?? info.table,
+      column: err.column ?? info.column,
+      rowKey: err.rowKey ?? info.rowKey,
+      range: err.range,
+    });
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new DiagnosticError({
+    code: errorCodeFromMessage(message),
+    message: `${info.messagePrefix}: ${message}`,
+    table: info.table,
+    column: info.column,
+    rowKey: info.rowKey,
+  });
 }
 
 function evaluatePivotTables(
@@ -1006,6 +1048,7 @@ function evaluatePivotTables(
     let columnValues: Scalar[];
     if (pivot.columns.range) {
       columnValues = buildDateRangeValues(
+        name,
         pivot.columns.range.start,
         pivot.columns.range.end,
         pivot.columns.range.step ?? "day",
@@ -1039,7 +1082,17 @@ function evaluatePivotTables(
 
     const pairAggregates = new Map<string, Scalar>();
     for (const [key, values] of pairValueBuckets.entries()) {
-      pairAggregates.set(key, computeAggregateValues("sum", values));
+      try {
+        pairAggregates.set(key, computeAggregateValues("sum", values));
+      } catch (err) {
+        const [rowKeyRaw, columnKeyRaw] = key.split("\u0000");
+        throw toPivotDiagnostic(err, {
+          table: name,
+          rowKey: rowKeyRaw,
+          column: columnKeyRaw,
+          messagePrefix: `[pivot-table] table ${name} cell row=${rowKeyRaw} column=${columnKeyRaw}`,
+        });
+      }
     }
 
     const evaluatedRows = rowAxis.map((rowAxisEntry) => {
@@ -1048,7 +1101,16 @@ function evaluatePivotTables(
       for (const columnAxisEntry of columnAxis) {
         const key = pairKey(rowAxisEntry.key, columnAxisEntry.key);
         if (!pairValueBuckets.has(key)) {
-          values[columnAxisEntry.label] = emptyPivotCell(pivot.empty_cells);
+          try {
+            values[columnAxisEntry.label] = emptyPivotCell(pivot.empty_cells);
+          } catch (err) {
+            throw toPivotDiagnostic(err, {
+              table: name,
+              rowKey: String(rowAxisEntry.key),
+              column: "empty_cells",
+              messagePrefix: `[pivot-table] table ${name} cell row=${String(rowAxisEntry.key)} column=${columnAxisEntry.label}`,
+            });
+          }
           continue;
         }
         values[columnAxisEntry.label] = pairAggregates.get(key) ?? 0;

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -27,6 +27,7 @@ import type {
 const NUMERIC_RE = /^-?\d+(?:\.\d+)?$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_RE = /^\d+:\d{2}$/;
+const SHORT_MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"] as const;
 
 type ColumnType = "number" | "string" | "date" | "bool" | "time" | undefined;
 type LookupRowFn = (table: string, key: Scalar) => Record<string, Scalar>;
@@ -955,6 +956,38 @@ function addUtcMonthsClamped(date: Date, months: number): Date {
   return next;
 }
 
+function derivePivotColumnLabel(
+  pivotName: string,
+  key: Scalar,
+  labelMode: string | undefined,
+): string {
+  const raw = String(key);
+  if (!labelMode || labelMode === "iso_date") return raw;
+
+  if (labelMode === "short_month_day") {
+    if (!DATE_RE.test(raw)) {
+      throw new DiagnosticError({
+        code: "E_FRONTMATTER",
+        message: `pivot_table ${pivotName} columns.label short_month_day requires ISO date keys`,
+        table: pivotName,
+        column: "columns.label",
+        range: lineRange(0),
+      });
+    }
+    const [, monthText, dayText] = raw.split("-");
+    const month = Number(monthText);
+    return `${SHORT_MONTHS[month - 1]}_${dayText}`;
+  }
+
+  throw new DiagnosticError({
+    code: "E_FRONTMATTER",
+    message: `pivot_table ${pivotName} columns.label must be one of iso_date, short_month_day`,
+    table: pivotName,
+    column: "columns.label",
+    range: lineRange(0),
+  });
+}
+
 function buildDateRangeValues(
   pivotName: string,
   start: string,
@@ -1085,7 +1118,12 @@ function evaluatePivotTables(
     }
 
     const rowAxis = rowValues.map((key, index) => ({ id: scalarIdentity(key), key, label: String(key), index }));
-    const columnAxis = columnValues.map((key, index) => ({ id: scalarIdentity(key), key, label: String(key), index }));
+    const columnAxis = columnValues.map((key, index) => ({
+      id: scalarIdentity(key),
+      key,
+      label: derivePivotColumnLabel(name, key, pivot.columns.label),
+      index,
+    }));
 
     const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
     const pairValueBuckets = new Map<string, Scalar[]>();

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1018,30 +1018,40 @@ function evaluatePivotTables(
     const rowAxis = rowValues.map((key, index) => ({ key, label: String(key), index }));
     const columnAxis = columnValues.map((key, index) => ({ key, label: String(key), index }));
 
+    const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
+    const pairValueBuckets = new Map<string, Scalar[]>();
+    const pairKey = (rowKey: Scalar, columnKey: Scalar) => `${String(rowKey)}\u0000${String(columnKey)}`;
+
+    for (const row of ensuredSourceRows) {
+      const rowKey = row[rowRef.column];
+      const colKey = row[columnRef.column];
+      if (rowKey === null || rowKey === undefined || colKey === null || colKey === undefined) {
+        continue;
+      }
+      const key = pairKey(rowKey, colKey);
+      const bucket = pairValueBuckets.get(key);
+      if (bucket) {
+        bucket.push(row[valueColumn]);
+      } else {
+        pairValueBuckets.set(key, [row[valueColumn]]);
+      }
+    }
+
+    const pairAggregates = new Map<string, Scalar>();
+    for (const [key, values] of pairValueBuckets.entries()) {
+      pairAggregates.set(key, computeAggregateValues("sum", values));
+    }
+
     const evaluatedRows = rowAxis.map((rowAxisEntry) => {
       const values = Object.create(null) as Record<string, Scalar>;
 
       for (const columnAxisEntry of columnAxis) {
-        const matching = sourceRows
-          .map((row) => ensureSource(row))
-          .filter((row) => {
-            const rowKey = row[rowRef.column];
-            const colKey = row[columnRef.column];
-            return rowKey !== null
-              && rowKey !== undefined
-              && colKey !== null
-              && colKey !== undefined
-              && String(rowKey) === String(rowAxisEntry.key)
-              && String(colKey) === String(columnAxisEntry.key);
-          });
-
-        if (matching.length === 0) {
+        const key = pairKey(rowAxisEntry.key, columnAxisEntry.key);
+        if (!pairValueBuckets.has(key)) {
           values[columnAxisEntry.label] = emptyPivotCell(pivot.empty_cells);
           continue;
         }
-
-        const aggValues = matching.map((row) => row[valueColumn]);
-        values[columnAxisEntry.label] = computeAggregateValues("sum", aggValues);
+        values[columnAxisEntry.label] = pairAggregates.get(key) ?? 0;
       }
 
       const rowTotal = pivot.totals?.row

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -13,6 +13,8 @@ import type {
   ExpressionLimits,
   FrontmatterDocument,
   ParsedTable,
+  PivotTableDefinition,
+  PivotTableEvaluation,
   ReportTableDefinition,
   ReportTableEvaluation,
   Scalar,
@@ -33,7 +35,7 @@ interface EvalRowContext {
   [key: string]: Scalar | EvalRowContext;
 }
 
-type EvalKind = "computed" | "aggregate" | "summary-row" | "report-table";
+type EvalKind = "computed" | "aggregate" | "summary-row" | "report-table" | "pivot-table";
 
 type GroupedAggregate = {
   fn: string;
@@ -829,6 +831,274 @@ function evaluateReportTables(
   return results;
 }
 
+function parseColumnReference(sourceTable: string, reference: string): { table: string; column: string } {
+  if (!reference.includes(".")) {
+    return { table: sourceTable, column: reference };
+  }
+  const [table, column] = reference.split(".");
+  return { table, column };
+}
+
+function uniqueByString(values: Scalar[]): Scalar[] {
+  const seen = new Set<string>();
+  const out: Scalar[] = [];
+  for (const value of values) {
+    if (value === null || value === undefined) continue;
+    const key = String(value);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(value);
+  }
+  return out;
+}
+
+function applyRowOrdering(values: Scalar[], order: string[] | undefined): Scalar[] {
+  if (!order || order.length === 0) return values;
+  const remaining = [...values];
+  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [String(value), value]));
+  const ordered: Scalar[] = [];
+
+  for (const key of order) {
+    if (!remainingByKey.has(key)) continue;
+    ordered.push(remainingByKey.get(key)!);
+    remainingByKey.delete(key);
+  }
+
+  for (const value of remaining) {
+    const key = String(value);
+    if (!remainingByKey.has(key)) continue;
+    ordered.push(value);
+    remainingByKey.delete(key);
+  }
+
+  return ordered;
+}
+
+function parsePivotValueColumn(
+  pivotName: string,
+  source: string,
+  sourceSchema: TableFrontmatter,
+  expression: string,
+): string {
+  const match = expression.trim().match(/^sum\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)$/i);
+  if (!match) {
+    throw new DiagnosticError({
+      code: "E_FRONTMATTER",
+      message: `pivot_table ${pivotName} value must be sum(<column>) in v1`,
+      table: pivotName,
+      column: "value",
+      range: lineRange(0),
+    });
+  }
+  const column = match[1];
+  if (!sourceSchema.columns.includes(column)) {
+    throw new DiagnosticError({
+      code: "E_FRONTMATTER",
+      message: `pivot_table ${pivotName} value references unknown column ${column} in source table ${source}`,
+      table: pivotName,
+      column: "value",
+      range: lineRange(0),
+    });
+  }
+  return column;
+}
+
+function parseIsoDatePreserveYear(isoDate: string): Date {
+  const [yearText, monthText, dayText] = isoDate.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(Date.UTC(0, 0, 1));
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function formatIsoDate(date: Date): string {
+  const year = String(date.getUTCFullYear()).padStart(4, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function buildDateRangeValues(start: string, end: string, step: "day" | "week" | "month"): Scalar[] {
+  const values: Scalar[] = [];
+  const current = parseIsoDatePreserveYear(start);
+  const endDate = parseIsoDatePreserveYear(end);
+
+  let guard = 0;
+  while (current.getTime() <= endDate.getTime()) {
+    values.push(formatIsoDate(current));
+
+    const before = current.getTime();
+    if (step === "day") current.setUTCDate(current.getUTCDate() + 1);
+    else if (step === "week") current.setUTCDate(current.getUTCDate() + 7);
+    else current.setUTCMonth(current.getUTCMonth() + 1);
+
+    if (current.getTime() <= before) {
+      throw new Error("E_RANGE: invalid pivot date range increment");
+    }
+    guard += 1;
+    if (guard > 100000) {
+      throw new Error("E_LIMIT: pivot date range too large");
+    }
+  }
+
+  return values;
+}
+
+function emptyPivotCell(policy: PivotTableDefinition["empty_cells"] | undefined): Scalar {
+  switch (policy ?? "null") {
+    case "null":
+      return null;
+    case "zero":
+      return 0;
+    case "empty-string":
+      return "";
+    case "error":
+      throw new Error("E_EMPTY_CELL: no matching source rows for pivot cell");
+    default:
+      return null;
+  }
+}
+
+function toNumericOrNull(value: Scalar): Scalar {
+  return typeof value === "number" ? value : null;
+}
+
+function evaluatePivotTables(
+  pivotTables: Record<string, PivotTableDefinition> | undefined,
+  schemas: Record<string, TableFrontmatter>,
+  rowList: Record<string, Record<string, Scalar>[]>,
+  ensureByTable: Record<string, (row: Record<string, Scalar>) => Record<string, Scalar>>,
+): Record<string, PivotTableEvaluation> {
+  if (!pivotTables) return Object.create(null) as Record<string, PivotTableEvaluation>;
+
+  const results = Object.create(null) as Record<string, PivotTableEvaluation>;
+
+  for (const [name, pivot] of Object.entries(pivotTables)) {
+    const sourceRows = rowList[pivot.source] ?? [];
+    const ensureSource = ensureByTable[pivot.source];
+    const sourceSchema = schemas[pivot.source];
+
+    const rowRef = parseColumnReference(pivot.source, pivot.rows.from);
+    const columnRef = parseColumnReference(pivot.source, pivot.columns.from);
+    const valueColumn = parsePivotValueColumn(name, pivot.source, sourceSchema, pivot.value);
+
+    const rowAxisSourceRows = rowList[rowRef.table] ?? [];
+    const ensureRowAxisTable = ensureByTable[rowRef.table];
+    let rowValues = uniqueByString(rowAxisSourceRows.map((row) => ensureRowAxisTable(row)[rowRef.column]));
+    if (rowRef.table === pivot.source) {
+      rowValues = [...rowValues].sort((a, b) => String(a).localeCompare(String(b)));
+    }
+    rowValues = applyRowOrdering(rowValues, pivot.rows.order);
+
+    const columnAxisSourceRows = rowList[columnRef.table] ?? [];
+    const ensureColumnAxisTable = ensureByTable[columnRef.table];
+    let columnValues: Scalar[];
+    if (pivot.columns.range) {
+      columnValues = buildDateRangeValues(
+        pivot.columns.range.start,
+        pivot.columns.range.end,
+        pivot.columns.range.step ?? "day",
+      );
+    } else {
+      columnValues = uniqueByString(columnAxisSourceRows.map((row) => ensureColumnAxisTable(row)[columnRef.column]));
+      columnValues = [...columnValues].sort((a, b) => String(a).localeCompare(String(b)));
+    }
+
+    const rowAxis = rowValues.map((key, index) => ({ key, label: String(key), index }));
+    const columnAxis = columnValues.map((key, index) => ({ key, label: String(key), index }));
+
+    const evaluatedRows = rowAxis.map((rowAxisEntry) => {
+      const values = Object.create(null) as Record<string, Scalar>;
+
+      for (const columnAxisEntry of columnAxis) {
+        const matching = sourceRows
+          .map((row) => ensureSource(row))
+          .filter((row) => {
+            const rowKey = row[rowRef.column];
+            const colKey = row[columnRef.column];
+            return rowKey !== null
+              && rowKey !== undefined
+              && colKey !== null
+              && colKey !== undefined
+              && String(rowKey) === String(rowAxisEntry.key)
+              && String(colKey) === String(columnAxisEntry.key);
+          });
+
+        if (matching.length === 0) {
+          values[columnAxisEntry.label] = emptyPivotCell(pivot.empty_cells);
+          continue;
+        }
+
+        const aggValues = matching.map((row) => row[valueColumn]);
+        values[columnAxisEntry.label] = computeAggregateValues("sum", aggValues);
+      }
+
+      const rowTotal = pivot.totals?.row
+        ? computeAggregateValues("sum", Object.values(values).map(toNumericOrNull))
+        : undefined;
+
+      return {
+        key: rowAxisEntry.key,
+        values,
+        total: rowTotal,
+      };
+    });
+
+    let footerRows: PivotTableEvaluation["footerRows"];
+    if (pivot.totals?.column) {
+      footerRows = [];
+      for (const [footerName, footerDef] of Object.entries(pivot.totals.column)) {
+        const mode = footerDef.mode ?? "sum";
+        const footerValues = Object.create(null) as Record<string, Scalar>;
+        let running = 0;
+        for (const columnAxisEntry of columnAxis) {
+          const colTotal = computeAggregateValues(
+            "sum",
+            evaluatedRows.map((row) => toNumericOrNull(row.values[columnAxisEntry.label])),
+          );
+
+          if (mode === "running_sum") {
+            const numericColTotal = typeof colTotal === "number" ? colTotal : 0;
+            running += numericColTotal;
+            footerValues[columnAxisEntry.label] = running;
+          } else {
+            footerValues[columnAxisEntry.label] = colTotal;
+          }
+        }
+
+        const footerTotal = pivot.totals.row
+          ? computeAggregateValues("sum", Object.values(footerValues).map(toNumericOrNull))
+          : undefined;
+
+        footerRows.push({
+          key: footerName,
+          mode,
+          values: footerValues,
+          total: footerTotal,
+        });
+      }
+    }
+
+    results[name] = {
+      name,
+      source: pivot.source,
+      rowsFrom: pivot.rows.from,
+      columnsFrom: pivot.columns.from,
+      value: pivot.value,
+      rowAxis,
+      columnAxis,
+      rows: evaluatedRows,
+      rowTotalName: pivot.totals?.row,
+      footerRows,
+    };
+  }
+
+  return results;
+}
+
 function interpolateAggregates(
   body: string,
   aggregates: Record<string, Record<string, Scalar>>,
@@ -1210,6 +1480,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     groupedAggregateResults,
     limits,
   );
+  const pivotTableResults = evaluatePivotTables(frontmatter.pivot_tables, frontmatter.tables, rowList, ensureByTable);
 
   const results = Object.create(null) as Record<string, TableEvaluation>;
   for (const [name, rows] of Object.entries(rowList)) {
@@ -1256,6 +1527,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     frontmatter: frontmatter as FrontmatterDocument,
     tables: results,
     reportTables: reportTableResults,
+    pivotTables: pivotTableResults,
     rendered,
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -131,10 +131,43 @@ export interface ReportTableEvaluation {
   rows: Record<string, Scalar>[];
 }
 
+export interface PivotAxisEntry {
+  key: Scalar;
+  label: string;
+  index: number;
+}
+
+export interface PivotRowEvaluation {
+  key: Scalar;
+  values: Record<string, Scalar>;
+  total?: Scalar;
+}
+
+export interface PivotFooterRowEvaluation {
+  key: string;
+  mode: "sum" | "running_sum";
+  values: Record<string, Scalar>;
+  total?: Scalar;
+}
+
+export interface PivotTableEvaluation {
+  name: string;
+  source: string;
+  rowsFrom: string;
+  columnsFrom: string;
+  value: string;
+  rowAxis: PivotAxisEntry[];
+  columnAxis: PivotAxisEntry[];
+  rows: PivotRowEvaluation[];
+  rowTotalName?: string;
+  footerRows?: PivotFooterRowEvaluation[];
+}
+
 export interface CompileResult {
   frontmatter: FrontmatterDocument;
   tables: Record<string, TableEvaluation>;
   reportTables: Record<string, ReportTableEvaluation>;
+  pivotTables: Record<string, PivotTableEvaluation>;
   rendered: string;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,6 +132,7 @@ export interface ReportTableEvaluation {
 }
 
 export interface PivotAxisEntry {
+  id: string;
   key: Scalar;
   label: string;
   index: number;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": ["ES2020"],
     "types": ["node"],
     "strict": true,


### PR DESCRIPTION
## Summary
- add pivot table evaluation results to compile output (pivotTables)
- implement row/column axis generation for pivots
- evaluate pivot cells using value: sum(<column>)
- apply empty_cells behavior for unmatched cells
- implement row totals and column footer totals (sum, running_sum)
- add integration coverage for axis generation, cell evaluation, and totals
- update work-item checklist for sub-branch 2 completion

## Validation
- npm run -w @mdxtab/core build
- npm run -w @mdxtab/core test

Refs #38