### PR TITLE
Issue #38: pipeline + rendering for pivot tables

### DIFF
--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -147,10 +147,10 @@ synthetically (same model as `report_tables`).
 - [x] Names must satisfy identifier rules and not collide with axis headers.
 
 ### 6. Render injection
-- [ ] Detect `## <pivot_name>` headings and inject the rendered Markdown
+- [x] Detect `## <pivot_name>` headings and inject the rendered Markdown
       table (same mechanism as `report_tables`).
-- [ ] Preserve deterministic header and row order.
-- [ ] Source markdown remains unchanged; rendering occurs in preview/output
+- [x] Preserve deterministic header and row order.
+- [x] Source markdown remains unchanged; rendering occurs in preview/output
       and CLI `render` only.
 
 ### 7. Dependency graph & evaluation order
@@ -201,6 +201,7 @@ synthetically (same model as `report_tables`).
       render injection.
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
+- Progress: render injection for pivot headings completed.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -154,9 +154,9 @@ synthetically (same model as `report_tables`).
       and CLI `render` only.
 
 ### 7. Dependency graph & evaluation order
-- [ ] Register pivot tables after row evaluation and aggregates of the source
+- [x] Register pivot tables after row evaluation and aggregates of the source
       table.
-- [ ] Detect cycles if a pivot is referenced from another pivot or report
+- [x] Detect cycles if a pivot is referenced from another pivot or report
       table (deferred: pivot output is not addressable in expressions in MVP).
 
 ### 8. Tests
@@ -202,6 +202,7 @@ synthetically (same model as `report_tables`).
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
 - Progress: render injection for pivot headings completed.
+- Progress: synthetic dependency-order planning hooks added for report/pivot evaluation.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -197,6 +197,7 @@ synthetically (same model as `report_tables`).
 
 ### 3) Pipeline + rendering
 - Branch: `issue-38-pivot-render-pipeline`
+- PR: https://github.com/Frank-Yong/MDXTab/pull/41
 - Scope: evaluation order integration, dependency graph hooks, heading-based
       render injection.
 - Includes tasks: 6, 7

--- a/packages/core/src/__tests__/dependency-graph.spec.ts
+++ b/packages/core/src/__tests__/dependency-graph.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { lexExpression } from "../tokens.js";
 import { parseExpression } from "../parser.js";
-import { buildDependencyGraph } from "../dependency-graph.js";
+import { buildDependencyGraph, buildNameDependencyGraph } from "../dependency-graph.js";
 
 const ast = (expr: string) => parseExpression(lexExpression(expr));
 
@@ -62,5 +62,23 @@ describe("dependency graph", () => {
 
     expect(graph.edges).toEqual([{ from: "title", to: "role_id" }]);
     expect(graph.order).toEqual(["role_id", "title"]);
+  });
+
+  it("orders name dependencies with external nodes ignored", () => {
+    const graph = buildNameDependencyGraph({
+      "pivot:liquidity": ["table:entries"],
+      "report:overview": ["pivot:liquidity"],
+    });
+
+    expect(graph.order).toEqual(["pivot:liquidity", "report:overview"]);
+  });
+
+  it("detects cycles in name dependencies", () => {
+    expect(() =>
+      buildNameDependencyGraph({
+        "pivot:a": ["report:b"],
+        "report:b": ["pivot:a"],
+      }),
+    ).toThrow(/E_CYCLE/);
   });
 });

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1324,6 +1324,42 @@ pivot_tables:
     expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
   });
 
+  it("renders pivot rows correctly when column labels collide", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2025-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Salary | 200 |
+
+## liquidity
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.rendered).toContain("| category | apr_24 | apr_24 |");
+    expect(result.rendered).toContain("| Salary | 100 | 200 |");
+  });
+
   it("throws when short_month_day receives a calendar-invalid ISO date key", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1083,7 +1083,7 @@ pivot_tables:
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("does not fail when a manual markdown table exists under a pivot heading", () => {
+  it("replaces a manual markdown table under a pivot heading with rendered pivot output", () => {
     const pivotDoc = `---
 mdxtab: "1.0"
 tables:
@@ -1099,9 +1099,10 @@ pivot_tables:
       from: date
       range:
         start: 2026-04-24
-        end: 2026-05-24
+        end: 2026-04-25
         step: day
     value: sum(amount)
+    empty_cells: zero
 ---
 
 ## entries
@@ -1120,6 +1121,9 @@ pivot_tables:
 
     const result = compileMdxtab(pivotDoc);
     expect(result.rendered).toContain("## liquidity");
+    expect(result.rendered).toContain("| category | 2026-04-24 | 2026-04-25 |");
+    expect(result.rendered).toContain("| Salary | 100 | 0 |");
+    expect(result.rendered).not.toContain("| stale | old |");
   });
 
   it("evaluates pivot tables with range columns, row totals, and running footer", () => {

--- a/packages/core/src/dependency-graph.ts
+++ b/packages/core/src/dependency-graph.ts
@@ -12,6 +12,55 @@ export interface DependencyGraph {
   order: string[];
 }
 
+export function buildNameDependencyGraph(
+  nodes: Record<string, string[]>,
+  limits: ExpressionLimits = DEFAULT_EXPRESSION_LIMITS,
+): DependencyGraph {
+  const names = Object.keys(nodes);
+  const nameSet = new Set(names);
+  const edges: DependencyEdge[] = [];
+  const depMap: Record<string, Set<string>> = {};
+
+  for (const [name, deps] of Object.entries(nodes)) {
+    const depSet = new Set<string>(deps);
+    depMap[name] = depSet;
+    for (const dep of depSet) {
+      edges.push({ from: name, to: dep });
+    }
+  }
+
+  const order: string[] = [];
+  const state: Record<string, "visiting" | "visited"> = {};
+
+  const visit = (name: string, depth = 1) => {
+    try {
+      assertDependencyDepth(depth, limits);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`${message} while visiting ${name}`);
+    }
+
+    if (state[name] === "visited") return;
+    if (state[name] === "visiting") {
+      throw new Error(`E_CYCLE: dependency cycle involving ${name}`);
+    }
+
+    state[name] = "visiting";
+    for (const dep of depMap[name] ?? []) {
+      if (!nameSet.has(dep)) continue;
+      visit(dep, depth + 1);
+    }
+    state[name] = "visited";
+    order.push(name);
+  };
+
+  for (const name of names) {
+    visit(name);
+  }
+
+  return { edges, order };
+}
+
 export function buildDependencyGraph(
   nodes: Record<string, AstNode>,
   limits: ExpressionLimits = DEFAULT_EXPRESSION_LIMITS,

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1,4 +1,4 @@
-import { buildDependencyGraph } from "./dependency-graph.js";
+import { buildDependencyGraph, buildNameDependencyGraph } from "./dependency-graph.js";
 import { evaluateAst } from "./evaluator.js";
 import { parseExpression, type AstNode } from "./parser.js";
 import { parseFrontmatter } from "./frontmatter.js";
@@ -916,6 +916,50 @@ function parseColumnReference(sourceTable: string, reference: string): { table: 
   return { table, column };
 }
 
+function buildSyntheticEvaluationPlan(
+  reportTables: Record<string, ParsedReportTable>,
+  pivotTables: Record<string, PivotTableDefinition> | undefined,
+): { reportOrder: string[]; pivotOrder: string[] } {
+  const reportNames = new Set(Object.keys(reportTables));
+  const pivotNames = new Set(Object.keys(pivotTables ?? {}));
+  const nodes = Object.create(null) as Record<string, string[]>;
+
+  const syntheticNodeName = (name: string): string | undefined => {
+    if (reportNames.has(name)) return `report:${name}`;
+    if (pivotNames.has(name)) return `pivot:${name}`;
+    return undefined;
+  };
+
+  for (const [name, report] of Object.entries(reportTables)) {
+    const deps: string[] = [];
+    const dep = syntheticNodeName(report.rowsFrom);
+    if (dep) deps.push(dep);
+    nodes[`report:${name}`] = deps;
+  }
+
+  for (const [name, pivot] of Object.entries(pivotTables ?? {})) {
+    const deps = new Set<string>();
+    const rowRef = parseColumnReference(pivot.source, pivot.rows.from);
+    const columnRef = parseColumnReference(pivot.source, pivot.columns.from);
+    const candidates = [pivot.source, rowRef.table, columnRef.table];
+    for (const candidate of candidates) {
+      const dep = syntheticNodeName(candidate);
+      if (dep) deps.add(dep);
+    }
+    nodes[`pivot:${name}`] = [...deps];
+  }
+
+  const graph = buildNameDependencyGraph(nodes);
+  const reportOrder = graph.order
+    .filter((node) => node.startsWith("report:"))
+    .map((node) => node.slice("report:".length));
+  const pivotOrder = graph.order
+    .filter((node) => node.startsWith("pivot:"))
+    .map((node) => node.slice("pivot:".length));
+
+  return { reportOrder, pivotOrder };
+}
+
 function uniqueByString(values: Scalar[]): Scalar[] {
   const seen = new Set<string>();
   const out: Scalar[] = [];
@@ -1712,8 +1756,29 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
   }
 
   const parsedReportTables = parseReportTableExpressions(frontmatter.report_tables, limits);
+  let syntheticPlan: { reportOrder: string[]; pivotOrder: string[] };
+  try {
+    syntheticPlan = buildSyntheticEvaluationPlan(parsedReportTables, frontmatter.pivot_tables);
+  } catch (err) {
+    throw wrapExpressionDiagnostic(err, { table: "<synthetic>", target: "<dependency>", kind: "dependency" });
+  }
+
+  const orderedParsedReportTables = Object.create(null) as Record<string, ParsedReportTable>;
+  for (const name of syntheticPlan.reportOrder) {
+    if (Object.prototype.hasOwnProperty.call(parsedReportTables, name)) {
+      orderedParsedReportTables[name] = parsedReportTables[name];
+    }
+  }
+
+  const orderedPivotTables = Object.create(null) as Record<string, PivotTableDefinition>;
+  for (const name of syntheticPlan.pivotOrder) {
+    if (Object.prototype.hasOwnProperty.call(frontmatter.pivot_tables ?? {}, name)) {
+      orderedPivotTables[name] = (frontmatter.pivot_tables ?? {})[name];
+    }
+  }
+
   const reportTableResults = evaluateReportTables(
-    parsedReportTables,
+    orderedParsedReportTables,
     rowList,
     ensureByTable,
     lookupRow,
@@ -1721,7 +1786,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     groupedAggregateResults,
     limits,
   );
-  const pivotTableResults = evaluatePivotTables(frontmatter.pivot_tables, frontmatter.tables, rowList, ensureByTable);
+  const pivotTableResults = evaluatePivotTables(orderedPivotTables, frontmatter.tables, rowList, ensureByTable);
 
   const results = Object.create(null) as Record<string, TableEvaluation>;
   for (const [name, rows] of Object.entries(rowList)) {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -733,40 +733,46 @@ function renderMarkdownTable(columns: string[], rows: Record<string, Scalar>[]):
   return [header, separator, ...dataLines];
 }
 
+function renderMarkdownTableFromMatrix(headers: string[], rows: Scalar[][]): string[] {
+  const headerCells = headers.map((header) => formatScalar(header));
+  const header = `| ${headerCells.join(" | ")} |`;
+  const separator = `|${headerCells.map((cell) => "-".repeat(Math.max(cell.length + 2, 3))).join("|")}|`;
+  const dataLines = rows.map((cells) => `| ${cells.map((cell) => formatScalar(cell)).join(" | ")} |`);
+  return [header, separator, ...dataLines];
+}
+
 function renderPivotMarkdownTable(pivot: PivotTableEvaluation): string[] {
   const columns = [pivot.rowsFrom, ...pivot.columnAxis.map((entry) => entry.label)];
   if (pivot.rowTotalName) {
     columns.push(pivot.rowTotalName);
   }
 
-  const rows: Record<string, Scalar>[] = [];
+  const rows: Scalar[][] = [];
   for (let rowIndex = 0; rowIndex < pivot.rowAxis.length; rowIndex += 1) {
     const axis = pivot.rowAxis[rowIndex];
     const row = pivot.rows[rowIndex];
-    const out = Object.create(null) as Record<string, Scalar>;
-    out[pivot.rowsFrom] = axis.label;
+    const out: Scalar[] = [axis.label];
     for (const columnEntry of pivot.columnAxis) {
-      out[columnEntry.label] = row.values[columnEntry.id];
+      out.push(row.values[columnEntry.id]);
     }
     if (pivot.rowTotalName) {
-      out[pivot.rowTotalName] = row.total ?? null;
+      out.push(row.total ?? null);
     }
     rows.push(out);
   }
 
   for (const footer of pivot.footerRows ?? []) {
-    const out = Object.create(null) as Record<string, Scalar>;
-    out[pivot.rowsFrom] = footer.key;
+    const out: Scalar[] = [footer.key];
     for (const columnEntry of pivot.columnAxis) {
-      out[columnEntry.label] = footer.values[columnEntry.id];
+      out.push(footer.values[columnEntry.id]);
     }
     if (pivot.rowTotalName) {
-      out[pivot.rowTotalName] = footer.total ?? null;
+      out.push(footer.total ?? null);
     }
     rows.push(out);
   }
 
-  return renderMarkdownTable(columns, rows);
+  return renderMarkdownTableFromMatrix(columns, rows);
 }
 
 function isMarkdownTableStart(lines: string[], startIndex: number): boolean {
@@ -919,6 +925,7 @@ function parseColumnReference(sourceTable: string, reference: string): { table: 
 function buildSyntheticEvaluationPlan(
   reportTables: Record<string, ParsedReportTable>,
   pivotTables: Record<string, PivotTableDefinition> | undefined,
+  limits: ExpressionLimits,
 ): { reportOrder: string[]; pivotOrder: string[] } {
   const reportNames = new Set(Object.keys(reportTables));
   const pivotNames = new Set(Object.keys(pivotTables ?? {}));
@@ -949,7 +956,7 @@ function buildSyntheticEvaluationPlan(
     nodes[`pivot:${name}`] = [...deps];
   }
 
-  const graph = buildNameDependencyGraph(nodes);
+  const graph = buildNameDependencyGraph(nodes, limits);
   const reportOrder = graph.order
     .filter((node) => node.startsWith("report:"))
     .map((node) => node.slice("report:".length));
@@ -1758,7 +1765,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
   const parsedReportTables = parseReportTableExpressions(frontmatter.report_tables, limits);
   let syntheticPlan: { reportOrder: string[]; pivotOrder: string[] };
   try {
-    syntheticPlan = buildSyntheticEvaluationPlan(parsedReportTables, frontmatter.pivot_tables);
+    syntheticPlan = buildSyntheticEvaluationPlan(parsedReportTables, frontmatter.pivot_tables, limits);
   } catch (err) {
     throw wrapExpressionDiagnostic(err, { table: "<synthetic>", target: "<dependency>", kind: "dependency" });
   }

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -733,6 +733,42 @@ function renderMarkdownTable(columns: string[], rows: Record<string, Scalar>[]):
   return [header, separator, ...dataLines];
 }
 
+function renderPivotMarkdownTable(pivot: PivotTableEvaluation): string[] {
+  const columns = [pivot.rowsFrom, ...pivot.columnAxis.map((entry) => entry.label)];
+  if (pivot.rowTotalName) {
+    columns.push(pivot.rowTotalName);
+  }
+
+  const rows: Record<string, Scalar>[] = [];
+  for (let rowIndex = 0; rowIndex < pivot.rowAxis.length; rowIndex += 1) {
+    const axis = pivot.rowAxis[rowIndex];
+    const row = pivot.rows[rowIndex];
+    const out = Object.create(null) as Record<string, Scalar>;
+    out[pivot.rowsFrom] = axis.label;
+    for (const columnEntry of pivot.columnAxis) {
+      out[columnEntry.label] = row.values[columnEntry.id];
+    }
+    if (pivot.rowTotalName) {
+      out[pivot.rowTotalName] = row.total ?? null;
+    }
+    rows.push(out);
+  }
+
+  for (const footer of pivot.footerRows ?? []) {
+    const out = Object.create(null) as Record<string, Scalar>;
+    out[pivot.rowsFrom] = footer.key;
+    for (const columnEntry of pivot.columnAxis) {
+      out[columnEntry.label] = footer.values[columnEntry.id];
+    }
+    if (pivot.rowTotalName) {
+      out[pivot.rowTotalName] = footer.total ?? null;
+    }
+    rows.push(out);
+  }
+
+  return renderMarkdownTable(columns, rows);
+}
+
 function isMarkdownTableStart(lines: string[], startIndex: number): boolean {
   if (startIndex + 1 >= lines.length) return false;
   const header = lines[startIndex];
@@ -747,12 +783,9 @@ function isPipeDelimitedRow(line: string): boolean {
   return trimmed.startsWith("|") && trimmed.endsWith("|");
 }
 
-function injectReportTables(
-  body: string,
-  reportTables: Record<string, ReportTableEvaluation>,
-): string {
-  const hasOwnReportTable = (heading: string): heading is keyof typeof reportTables =>
-    Object.prototype.hasOwnProperty.call(reportTables, heading);
+function injectSyntheticMarkdownTables(body: string, tableLinesByHeading: Record<string, string[]>): string {
+  const hasOwnSyntheticTable = (heading: string): heading is keyof typeof tableLinesByHeading =>
+    Object.prototype.hasOwnProperty.call(tableLinesByHeading, heading);
   const lines = body.split("\n");
   const fencedLines = getFencedLines(lines);
   const headings = lines
@@ -763,12 +796,11 @@ function injectReportTables(
       heading: line.match(/^\s*#{1,6}\s+(.*)$/)?.[1].trim(),
     }))
     .filter((entry): entry is { index: number; heading: string } => Boolean(entry.heading))
-    .filter(({ heading }) => hasOwnReportTable(heading))
+    .filter(({ heading }) => hasOwnSyntheticTable(heading))
     .sort((a, b) => b.index - a.index);
 
   for (const { index, heading } of headings) {
-    const report = reportTables[heading];
-    const tableLines = renderMarkdownTable(report.columns, report.rows);
+    const tableLines = tableLinesByHeading[heading];
     let replaceStart = index + 1;
     while (replaceStart < lines.length && lines[replaceStart].trim() === "") {
       replaceStart += 1;
@@ -784,6 +816,28 @@ function injectReportTables(
   }
 
   return lines.join("\n");
+}
+
+function injectReportTables(
+  body: string,
+  reportTables: Record<string, ReportTableEvaluation>,
+): string {
+  const tableLinesByHeading = Object.create(null) as Record<string, string[]>;
+  for (const [name, report] of Object.entries(reportTables)) {
+    tableLinesByHeading[name] = renderMarkdownTable(report.columns, report.rows);
+  }
+  return injectSyntheticMarkdownTables(body, tableLinesByHeading);
+}
+
+function injectPivotTables(
+  body: string,
+  pivotTables: Record<string, PivotTableEvaluation>,
+): string {
+  const tableLinesByHeading = Object.create(null) as Record<string, string[]>;
+  for (const [name, pivot] of Object.entries(pivotTables)) {
+    tableLinesByHeading[name] = renderPivotMarkdownTable(pivot);
+  }
+  return injectSyntheticMarkdownTables(body, tableLinesByHeading);
 }
 
 function evaluateReportTables(
@@ -1704,6 +1758,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     );
   }
   renderedBody = injectReportTables(renderedBody, reportTableResults);
+  renderedBody = injectPivotTables(renderedBody, pivotTableResults);
   renderedBody = interpolateAggregates(renderedBody, aggregateResults, groupedAggregateResults, bodyOffset);
   if (!includeFrontmatter && renderedBody.startsWith("\n")) {
     renderedBody = renderedBody.slice(1);


### PR DESCRIPTION
## Summary
- add pivot markdown rendering and heading-based injection in compile pipeline
- add synthetic dependency-order planning hooks for report/pivot evaluation
- add/adjust tests for pivot render replacement and name-dependency graph behavior
- update work item tracking for tasks 6 and 7

## Validation
- npm run -w @mdxtab/core test -- src/__tests__/dependency-graph.spec.ts
- npm run -w @mdxtab/core test