### PR TITLE
Issue #38: docs and tooling polish for pivot_tables

### DIFF
--- a/dev/examples/pivot-liquidity.md
+++ b/dev/examples/pivot-liquidity.md
@@ -1,0 +1,51 @@
+---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+      order: [Salary, Food, Rent]
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-26
+        step: day
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+    totals:
+      row: total
+      column:
+        accumulated:
+          mode: running_sum
+---
+
+### Explanation
+Builds a synthetic liquidity matrix from event rows. Rows are categories, columns are daily dates, cells are sum(amount), row totals are enabled, and footer row accumulated is a running sum across column totals.
+
+## entries
+
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Salary | 50 |
+| e3 | 2026-04-25 | Food | -30 |
+| e4 | 2026-04-26 | Rent | -40 |
+
+## liquidity
+
+### Expected (rendered)
+- Header contains apr_24, apr_25, apr_26, total.
+- Salary row values are 100, 50, 0 with total 150.
+- Food row values are 0, -30, 0 with total -30.
+- Rent row values are 0, 0, -40 with total -40.
+- Footer row accumulated is 100, 120, 80 with total 300.

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-render-pipeline` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-docs-tooling` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -202,8 +202,7 @@ synthetically (same model as `report_tables`).
       render injection.
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
-- Progress: render injection for pivot headings completed.
-- Progress: synthetic dependency-order planning hooks added for report/pivot evaluation.
+- Progress: merged into `issue-38-pivot-tables`.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -206,6 +206,7 @@ synthetically (same model as `report_tables`).
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`
+- PR: https://github.com/Frank-Yong/MDXTab/pull/42
 - Scope: spec/docs updates, examples, optional VS Code/schema/snippet polish.
 - Includes tasks: 9, 10
 - Progress: task 9 docs/spec and task 10 VS Code tooling updates completed.

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -175,9 +175,9 @@ synthetically (same model as `report_tables`).
       `dev/examples/`.
 
 ### 10. Tooling (follow-up, not blocking MVP)
-- [ ] Snippets for `pivot_tables`.
-- [ ] Schema-command output includes `pivot_tables`.
-- [ ] Hover/completion in the VS Code extension.
+- [x] Snippets for `pivot_tables`.
+- [x] Schema-command output includes `pivot_tables`.
+- [x] Hover/completion in the VS Code extension.
 
 ## Sub-branch plan (4 PRs)
 
@@ -208,6 +208,7 @@ synthetically (same model as `report_tables`).
 - Branch: `issue-38-pivot-docs-tooling`
 - Scope: spec/docs updates, examples, optional VS Code/schema/snippet polish.
 - Includes tasks: 9, 10
+- Progress: task 9 docs/spec and task 10 VS Code tooling updates completed.
 
 ### Merge order
 1. `issue-38-pivot-schema-validation`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -169,9 +169,9 @@ synthetically (same model as `report_tables`).
       collisions.
 
 ### 9. Docs & spec
-- [ ] Update `specs/formal-format-spec.md` with the `pivot_tables` schema and
+- [x] Update `specs/formal-format-spec.md` with the `pivot_tables` schema and
       evaluation order entry.
-- [ ] Add `docs/format-overview.md` mention and a worked example under
+- [x] Add `docs/format-overview.md` mention and a worked example under
       `dev/examples/`.
 
 ### 10. Tooling (follow-up, not blocking MVP)

--- a/docs/format-overview.md
+++ b/docs/format-overview.md
@@ -38,12 +38,20 @@ tables:
 - `aggregates`: table-wide results (`sum`, `avg`, `min`, `max`, `count`)
 - `summary_rows`: synthetic footer-style rows
 - `report_tables`: synthetic derived tables rendered at matching headings
+- `pivot_tables`: synthetic matrix tables rendered at matching headings
 
 ## Common expression inputs
 
 - `row.<column>` for current row values
 - aggregate functions like `sum(net)`
 - lookup paths like `transactions.total_by_category[row.id]`
+
+## Pivot tables
+
+- Use `pivot_tables` when you need a matrix layout such as `category x date`.
+- Define `source`, `rows.from`, `columns.from`, and `value`.
+- Optional `columns.range` generates a deterministic date axis (`day`, `week`, `month`).
+- Optional `totals` adds row-total and footer rows.
 
 ## Design rule
 
@@ -55,6 +63,7 @@ Keep formulas in frontmatter and keep markdown tables as data only.
 - `dev/examples/time-entries.md`
 - `dev/examples/grouped-aggregates.md`
 - `dev/examples/transactions.md`
+- `dev/examples/pivot-liquidity.md`
 
 ## Next
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,12 +4,14 @@
 
 - Command: **MDXTab: Render Preview** (`mdxtab.renderPreview`) — renders the active Markdown file through the MDXTab compiler into a preview document.
 - Command: **MDXTab: Validate Document** (`mdxtab.validateDocument`) — validates the active Markdown file and reports diagnostic count/status.
-- Command: **MDXTab: Show Table Schema** (`mdxtab.showTableSchema`) — opens a markdown view with the parsed `tables` frontmatter schema as JSON.
+- Command: **MDXTab: Show Table Schema** (`mdxtab.showTableSchema`) — opens a markdown view with parsed `tables`, `report_tables`, and `pivot_tables` frontmatter schema as JSON.
 - Diagnostics: recompiles on open/change/save; errors surface as markdown diagnostics at the top of the file.
 - Preview scheme: `mdxtab-preview:` opens a virtual document with the rendered output (frontmatter + interpolated aggregates).
 - **Computed column preview**: columns defined in frontmatter `computed` are rendered in the Markdown preview with their evaluated per-row values. Columns already authored as headers have their empty cells filled in; columns not in the source table are appended automatically.
 - **Summary row preview**: rows defined in frontmatter `summary_rows` are rendered as synthetic rows appended at the bottom of the table preview.
 - **Synthetic report table preview**: frontmatter `report_tables` render as derived Markdown tables at matching headings such as `## category_balances`.
+- **Synthetic pivot table preview**: frontmatter `pivot_tables` render as derived matrix tables at matching headings such as `## liquidity`.
+- **Heading completion + hover for synthetic tables**: completion suggests `report_tables` and `pivot_tables` names when editing Markdown headings, and hover shows quick details on matching synthetic-table headings.
 - **Expression guardrails**: validation rejects pathological computed/aggregate
   expressions with `E_LIMIT` diagnostics before they can trigger stack overflow
   or excessive work.

--- a/packages/vscode/snippets/mdxtab.markdown.json
+++ b/packages/vscode/snippets/mdxtab.markdown.json
@@ -26,5 +26,32 @@
       "| ${4} | ${5} |"
     ],
     "description": "Insert a basic MDXTab table scaffold."
+  },
+  "MDXTab pivot table": {
+    "prefix": "mdxtab-pivot",
+    "body": [
+      "pivot_tables:",
+      "  ${1:pivot_name}:",
+      "    source: ${2:entries}",
+      "    rows:",
+      "      from: ${3:category}",
+      "    columns:",
+      "      from: ${4:date}",
+      "      range:",
+      "        start: ${5:2026-04-24}",
+      "        end: ${6:2026-04-26}",
+      "        step: ${7:day}",
+      "      label: ${8:short_month_day}",
+      "    value: sum(${9:amount})",
+      "    empty_cells: ${10:zero}",
+      "    totals:",
+      "      row: ${11:total}",
+      "      column:",
+      "        ${12:accumulated}:",
+      "          mode: ${13:running_sum}",
+      "",
+      "## ${1:pivot_name}"
+    ],
+    "description": "Insert a pivot_tables scaffold with a matching render heading."
   }
 }

--- a/packages/vscode/snippets/mdxtab.markdown.json
+++ b/packages/vscode/snippets/mdxtab.markdown.json
@@ -27,7 +27,7 @@
     ],
     "description": "Insert a basic MDXTab table scaffold."
   },
-  "MDXTab pivot table": {
+  "MDXTab pivot frontmatter block": {
     "prefix": "mdxtab-pivot",
     "body": [
       "pivot_tables:",
@@ -48,10 +48,15 @@
       "      row: ${11:total}",
       "      column:",
       "        ${12:accumulated}:",
-      "          mode: ${13:running_sum}",
-      "",
+      "          mode: ${13:running_sum}"
+    ],
+    "description": "Insert a pivot_tables frontmatter scaffold."
+  },
+  "MDXTab pivot render heading": {
+    "prefix": "mdxtab-pivot-heading",
+    "body": [
       "## ${1:pivot_name}"
     ],
-    "description": "Insert a pivot_tables scaffold with a matching render heading."
+    "description": "Insert a Markdown heading render target for a pivot table."
   }
 }

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -604,4 +604,39 @@ describe("vscode extension smoke", () => {
     expect(hover?.contents.value).toContain("category-balances.rows_from");
     expect(hover?.contents.value).toContain("rows_from=entries");
   });
+
+  it("provides hover details for pivot table headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "date", "category", "amount"],
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "entries",
+          rows: { from: "category" },
+          columns: { from: "date" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/hover-pivot-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, date, category, amount]\n---\n\n## liquidity\n",
+    );
+
+    const hover = state.hoverProvider?.provideHover(sourceDoc, new vscode.Position(7, 6)) as { contents: { value: string } } | undefined;
+    expect(hover?.contents.value).toContain("Pivot Table");
+    expect(hover?.contents.value).toContain("liquidity.source");
+    expect(hover?.contents.value).toContain("source=entries");
+    expect(hover?.contents.value).toContain("rows.from=category");
+  });
 });

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -419,7 +419,25 @@ describe("vscode extension smoke", () => {
           columns: ["id", "amount"],
         },
       },
-    });
+      report_tables: {
+        category_balances: {
+          rows_from: "expenses",
+          columns: ["label", "total"],
+          cells: {
+            label: "row.id",
+            total: "expenses.sum_total",
+          },
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "expenses",
+          rows: { from: "id" },
+          columns: { from: "amount" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
 
     const sourceUri = MockUri.from({ scheme: "file", path: "/tmp/schema.md" });
     const sourceDoc = createDoc(
@@ -437,6 +455,8 @@ describe("vscode extension smoke", () => {
     expect(state.virtualDocumentContents.length).toBe(1);
     expect(state.virtualDocumentContents[0]).toContain("# MDXTab Table Schema");
     expect(state.virtualDocumentContents[0]).toContain('"expenses"');
+    expect(state.virtualDocumentContents[0]).toContain('"report_tables"');
+    expect(state.virtualDocumentContents[0]).toContain('"pivot_tables"');
   });
 
   it("warns when show-table-schema runs on a non-MDXTab file", async () => {

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = {
   commands: new Map<string, (...args: unknown[]) => unknown>(),
   previewProvider: undefined as undefined | { provideTextDocumentContent: (uri: unknown) => Promise<string> },
+  hoverProvider: undefined as undefined | { provideHover: (document: MockDocument, position: MockPosition) => unknown },
+  completionProvider: undefined as undefined | {
+    provideCompletionItems: (document: MockDocument, position: MockPosition) => Array<{ label: string }>;
+  },
   openHandlers: [] as Array<(doc: MockDocument) => void>,
   closeHandlers: [] as Array<(doc: MockDocument) => void>,
   changeHandlers: [] as Array<(event: { document: MockDocument }) => void>,
@@ -225,8 +229,19 @@ vi.mock("vscode", () => {
   const languages = {
     createDiagnosticCollection: vi.fn(() => diagnosticCollection),
     registerDocumentSymbolProvider: vi.fn(() => ({ dispose: () => undefined })),
-    registerHoverProvider: vi.fn(() => ({ dispose: () => undefined })),
-    registerCompletionItemProvider: vi.fn(() => ({ dispose: () => undefined })),
+    registerHoverProvider: vi.fn((_selector: unknown, provider: { provideHover: (document: MockDocument, position: MockPosition) => unknown }) => {
+      state.hoverProvider = provider;
+      return { dispose: () => undefined };
+    }),
+    registerCompletionItemProvider: vi.fn(
+      (
+        _selector: unknown,
+        provider: { provideCompletionItems: (document: MockDocument, position: MockPosition) => Array<{ label: string }> },
+      ) => {
+        state.completionProvider = provider;
+        return { dispose: () => undefined };
+      },
+    ),
     registerDefinitionProvider: vi.fn(() => ({ dispose: () => undefined })),
     registerCodeActionsProvider: vi.fn(() => ({ dispose: () => undefined })),
   };
@@ -288,6 +303,8 @@ describe("vscode extension smoke", () => {
   beforeEach(() => {
     state.commands.clear();
     state.previewProvider = undefined;
+    state.hoverProvider = undefined;
+    state.completionProvider = undefined;
     state.openHandlers.length = 0;
     state.closeHandlers.length = 0;
     state.changeHandlers.length = 0;
@@ -506,5 +523,85 @@ describe("vscode extension smoke", () => {
       "MDXTab: could not read table schema from frontmatter: invalid YAML near line 2",
     );
     expect(state.shownDocumentCount).toBe(0);
+  });
+
+  it("provides completion items for synthetic table names in headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+      report_tables: {
+        "category-balances": {
+          rows_from: "entries",
+          columns: ["label"],
+          cells: {
+            label: "row.id",
+          },
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "entries",
+          rows: { from: "id" },
+          columns: { from: "id" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/completion-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, amount]\n---\n\n## \n",
+    );
+
+    const items = state.completionProvider?.provideCompletionItems(sourceDoc, new vscode.Position(7, 3)) ?? [];
+    const labels = items.map((item) => item.label);
+
+    expect(labels).toContain("category-balances");
+    expect(labels).toContain("liquidity");
+  });
+
+  it("provides hover details for synthetic table headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+      report_tables: {
+        "category-balances": {
+          rows_from: "entries",
+          columns: ["label", "total"],
+          cells: {
+            label: "row.id",
+            total: "entries.total",
+          },
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/hover-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, amount]\n---\n\n## category-balances\n",
+    );
+
+    const hover = state.hoverProvider?.provideHover(sourceDoc, new vscode.Position(7, 6)) as { contents: { value: string } } | undefined;
+    expect(hover?.contents.value).toContain("Report Table");
+    expect(hover?.contents.value).toContain("category-balances.rows_from");
+    expect(hover?.contents.value).toContain("rows_from=entries");
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -491,16 +491,14 @@ function findBodyHoverEntry(
   tables: ReturnType<typeof parseMarkdownTables>,
 ): HoverEntry | undefined {
   const lineText = lines[position.line] ?? "";
-  const headingMatch = lineText.match(/^\s*#{1,6}\s+([A-Za-z0-9_]+)\s*$/);
-  if (headingMatch) {
-    const heading = headingMatch[1];
-    const start = lineText.indexOf(heading);
-    const end = start + heading.length;
+  const heading = extractHeadingInfo(lineText);
+  if (heading) {
+    const { text, start, end } = heading;
     if (position.character >= start && position.character <= end) {
-      const report = frontmatter.report_tables?.[heading];
+      const report = frontmatter.report_tables?.[text];
       if (report) {
         return {
-          table: heading,
+          table: text,
           kind: "report-table",
           name: "rows_from",
           expr: `rows_from=${report.rows_from}, columns=${report.columns.join(", ")}`,
@@ -511,10 +509,10 @@ function findBodyHoverEntry(
           exprEnd: end,
         };
       }
-      const pivot = frontmatter.pivot_tables?.[heading];
+      const pivot = frontmatter.pivot_tables?.[text];
       if (pivot) {
         return {
-          table: heading,
+          table: text,
           kind: "pivot-table",
           name: "source",
           expr: `source=${pivot.source}, rows.from=${pivot.rows.from}, columns.from=${pivot.columns.from}, value=${pivot.value}`,
@@ -599,12 +597,23 @@ function matchInterpolationStart(line: string, position: number): { start: numbe
 }
 
 function matchHeadingStart(line: string, position: number): { start: number } | undefined {
-  const headingMatch = line.match(/^\s*#{1,6}\s+([A-Za-z0-9_]*)$/);
-  if (!headingMatch) return undefined;
-  const start = line.indexOf(headingMatch[1]);
-  const end = start + headingMatch[1].length;
+  const heading = extractHeadingInfo(line);
+  if (!heading) return undefined;
+  const { start, end } = heading;
   if (position < start || position > end) return undefined;
   return { start };
+}
+
+function extractHeadingInfo(line: string): { text: string; start: number; end: number } | undefined {
+  const markerMatch = line.match(/^\s*#{1,6}\s+/);
+  if (!markerMatch) return undefined;
+  const rawHeading = line.slice(markerMatch[0].length);
+  const text = rawHeading.trim();
+  if (!text) return undefined;
+  const leadingWhitespace = rawHeading.match(/^\s*/)?.[0].length ?? 0;
+  const start = markerMatch[0].length + leadingWhitespace;
+  const end = start + text.length;
+  return { text, start, end };
 }
 
 function findDotCompletionTable(

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -207,7 +207,7 @@ class MdxtabCompletionProvider {
     if (document.languageId !== "markdown") return [];
     const context = getParsedContext(document, this.cache);
     if (!context.frontmatter || !context.frontmatterBounds) return [];
-    const { frontmatter: parsedFrontmatter, tables: parsedTables, entries, lines } = context;
+    const { frontmatter: parsedFrontmatter, tables: parsedTables, entries, lines, fencedLines } = context;
     const entry = entries.find(
       (item) =>
         item.line === position.line && position.character >= item.exprStart && position.character <= item.exprEnd,
@@ -244,7 +244,9 @@ class MdxtabCompletionProvider {
     }
 
     if (parsedFrontmatter && parsedTables) {
-      const headingStart = matchHeadingStart(lines[position.line] ?? "", position.character);
+      const headingStart = fencedLines.has(position.line)
+        ? undefined
+        : matchHeadingStart(lines[position.line] ?? "", position.character);
       if (headingStart) {
         for (const name of Object.keys(parsedFrontmatter.report_tables ?? {})) {
           items.push(new CompletionItem(name, CompletionItemKind.Struct));
@@ -389,7 +391,7 @@ function findHoverEntry(
   cache: Map<string, ParsedContext>,
 ): HoverEntry | undefined {
   const context = getParsedContext(document, cache);
-  const { lines, frontmatterBounds, frontmatter, tables, entries } = context;
+  const { lines, frontmatterBounds, frontmatter, tables, entries, fencedLines } = context;
   if (!frontmatterBounds) return undefined;
 
   if (position.line > frontmatterBounds.start && position.line < frontmatterBounds.end) {
@@ -401,7 +403,7 @@ function findHoverEntry(
   }
 
   if (frontmatter && tables) {
-    return findBodyHoverEntry(lines, position, frontmatter, tables);
+    return findBodyHoverEntry(lines, position, frontmatter, tables, fencedLines);
   }
 
   return undefined;
@@ -413,6 +415,33 @@ function getFrontmatterBounds(lines: string[]): { start: number; end: number } |
     if (lines[i].trim() === "---") return { start: 0, end: i };
   }
   return undefined;
+}
+
+function getFencedLines(lines: string[]): Set<number> {
+  const fencedLines = new Set<number>();
+  let inFence = false;
+  let fenceTicks = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (inFence) {
+      fencedLines.add(i);
+      const closeRe = new RegExp(`^\\s*` + "`".repeat(fenceTicks) + `\\s*$`);
+      if (closeRe.test(lines[i])) {
+        inFence = false;
+        fenceTicks = 0;
+      }
+      continue;
+    }
+
+    const openMatch = lines[i].match(/^\s*(`{3,})/);
+    if (openMatch) {
+      inFence = true;
+      fenceTicks = openMatch[1].length;
+      fencedLines.add(i);
+    }
+  }
+
+  return fencedLines;
 }
 
 function parseFrontmatterEntries(lines: string[], start: number, end: number): HoverEntry[] {
@@ -489,7 +518,9 @@ function findBodyHoverEntry(
   position: Position,
   frontmatter: ReturnType<typeof parseFrontmatter>,
   tables: ReturnType<typeof parseMarkdownTables>,
+  fencedLines: Set<number>,
 ): HoverEntry | undefined {
+  if (fencedLines.has(position.line)) return undefined;
   const lineText = lines[position.line] ?? "";
   const heading = extractHeadingInfo(lineText);
   if (heading) {
@@ -1033,6 +1064,7 @@ function extractContextValue(message: string, key: string): string | undefined {
 type ParsedContext = {
   version: number;
   lines: string[];
+  fencedLines: Set<number>;
   frontmatterBounds?: { start: number; end: number };
   frontmatter?: ReturnType<typeof parseFrontmatter>;
   tables?: ReturnType<typeof parseMarkdownTables>;
@@ -1046,6 +1078,7 @@ function getParsedContext(document: TextDocument, cache: Map<string, ParsedConte
 
   const text = document.getText();
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const fencedLines = getFencedLines(lines);
   const frontmatterBounds = getFrontmatterBounds(lines);
   let frontmatter: ReturnType<typeof parseFrontmatter> | undefined;
   let tables: ReturnType<typeof parseMarkdownTables> | undefined;
@@ -1066,6 +1099,7 @@ function getParsedContext(document: TextDocument, cache: Map<string, ParsedConte
   const parsed: ParsedContext = {
     version: document.version,
     lines,
+    fencedLines,
     frontmatterBounds,
     frontmatter,
     tables,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -609,7 +609,6 @@ function extractHeadingInfo(line: string): { text: string; start: number; end: n
   if (!markerMatch) return undefined;
   const rawHeading = line.slice(markerMatch[0].length);
   const text = rawHeading.trim();
-  if (!text) return undefined;
   const leadingWhitespace = rawHeading.match(/^\s*/)?.[0].length ?? 0;
   const start = markerMatch[0].length + leadingWhitespace;
   const end = start + text.length;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -168,7 +168,7 @@ class MdxtabSymbolProvider implements DocumentSymbolProvider {
 
 type HoverEntry = {
   table: string;
-  kind: "computed" | "aggregate";
+  kind: "computed" | "aggregate" | "report-table" | "pivot-table";
   name: string;
   expr: string;
   line: number;
@@ -186,7 +186,14 @@ class MdxtabHoverProvider implements HoverProvider {
     const entry = findHoverEntry(document, position, this.cache);
     if (!entry) return undefined;
 
-    const title = entry.kind === "computed" ? "Computed" : "Aggregate";
+    const title =
+      entry.kind === "computed"
+        ? "Computed"
+        : entry.kind === "aggregate"
+        ? "Aggregate"
+        : entry.kind === "report-table"
+        ? "Report Table"
+        : "Pivot Table";
     const label = `${entry.table}.${entry.name}`;
     const md = new MarkdownString(`**${title}:** ${label}\n\n\`${entry.expr}\``);
     return new Hover(md);
@@ -237,6 +244,17 @@ class MdxtabCompletionProvider {
     }
 
     if (parsedFrontmatter && parsedTables) {
+      const headingStart = matchHeadingStart(lines[position.line] ?? "", position.character);
+      if (headingStart) {
+        for (const name of Object.keys(parsedFrontmatter.report_tables ?? {})) {
+          items.push(new CompletionItem(name, CompletionItemKind.Struct));
+        }
+        for (const name of Object.keys(parsedFrontmatter.pivot_tables ?? {})) {
+          items.push(new CompletionItem(name, CompletionItemKind.Struct));
+        }
+        return items;
+      }
+
       const interpolation = matchAggregateInterpolation(lines[position.line] ?? "", position.character);
       if (interpolation) {
         const table = parsedFrontmatter.tables[interpolation.table];
@@ -473,6 +491,43 @@ function findBodyHoverEntry(
   tables: ReturnType<typeof parseMarkdownTables>,
 ): HoverEntry | undefined {
   const lineText = lines[position.line] ?? "";
+  const headingMatch = lineText.match(/^\s*#{1,6}\s+([A-Za-z0-9_]+)\s*$/);
+  if (headingMatch) {
+    const heading = headingMatch[1];
+    const start = lineText.indexOf(heading);
+    const end = start + heading.length;
+    if (position.character >= start && position.character <= end) {
+      const report = frontmatter.report_tables?.[heading];
+      if (report) {
+        return {
+          table: heading,
+          kind: "report-table",
+          name: "rows_from",
+          expr: `rows_from=${report.rows_from}, columns=${report.columns.join(", ")}`,
+          line: position.line,
+          start,
+          end,
+          exprStart: start,
+          exprEnd: end,
+        };
+      }
+      const pivot = frontmatter.pivot_tables?.[heading];
+      if (pivot) {
+        return {
+          table: heading,
+          kind: "pivot-table",
+          name: "source",
+          expr: `source=${pivot.source}, rows.from=${pivot.rows.from}, columns.from=${pivot.columns.from}, value=${pivot.value}`,
+          line: position.line,
+          start,
+          end,
+          exprStart: start,
+          exprEnd: end,
+        };
+      }
+    }
+  }
+
   const aggregateMatch = matchAggregateInterpolation(lineText, position.character);
   if (aggregateMatch) {
     const table = frontmatter.tables[aggregateMatch.table];
@@ -541,6 +596,15 @@ function matchInterpolationStart(line: string, position: number): { start: numbe
   const endIndex = line.indexOf("}}", startIndex + 2);
   if (endIndex !== -1 && endIndex < position) return undefined;
   return { start: startIndex };
+}
+
+function matchHeadingStart(line: string, position: number): { start: number } | undefined {
+  const headingMatch = line.match(/^\s*#{1,6}\s+([A-Za-z0-9_]*)$/);
+  if (!headingMatch) return undefined;
+  const start = line.indexOf(headingMatch[1]);
+  const end = start + headingMatch[1].length;
+  if (position < start || position > end) return undefined;
+  return { start };
 }
 
 function findDotCompletionTable(
@@ -1162,13 +1226,23 @@ export function activate(context: ExtensionContext) {
     }
 
     const tableCount = Object.keys(frontmatter.tables).length;
-    if (tableCount === 0) {
-      window.showInformationMessage("MDXTab: no table schemas found in frontmatter");
+    const reportCount = Object.keys(frontmatter.report_tables ?? {}).length;
+    const pivotCount = Object.keys(frontmatter.pivot_tables ?? {}).length;
+    if (tableCount === 0 && reportCount === 0 && pivotCount === 0) {
+      window.showInformationMessage("MDXTab: no schemas found in frontmatter");
       return;
     }
 
     try {
-      const schemaJson = JSON.stringify({ tables: frontmatter.tables }, null, 2);
+      const schemaJson = JSON.stringify(
+        {
+          tables: frontmatter.tables,
+          report_tables: frontmatter.report_tables ?? {},
+          pivot_tables: frontmatter.pivot_tables ?? {},
+        },
+        null,
+        2,
+      );
       const schemaDoc = await workspace.openTextDocument({
         language: "markdown",
         content: [

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -37,7 +37,7 @@ pivot_tables:                        # optional
     source: <tableName>
     rows:
       from: <columnName>|<tableName>.<columnName>
-      order: [<value>, ...]          # optional
+      order: [<string>, ...]         # optional
     columns:
       from: <columnName>|<tableName>.<columnName>
       range:                         # optional

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -49,7 +49,7 @@ pivot_tables:                        # optional
     key: <columnName>                # optional, default: source table key
     empty_cells: null|zero|empty-string|error  # optional, default: null
     totals:                          # optional
-      row: <columnName>
+      row: <name>
       column:
         <rowName>:
           mode: sum|running_sum      # optional, default: sum
@@ -80,7 +80,7 @@ pivot_tables:                        # optional
 - `pivot_tables.<name>.columns.range` is optional and requires ISO dates (`YYYY-MM-DD`) with `start <= end`; `step` is `day`, `week`, or `month`.
 - `pivot_tables.<name>.columns.label` supports `iso_date` and `short_month_day`.
 - `pivot_tables.<name>.value` in v1 must be `sum(<column>)` where `<column>` exists in the source table.
-- `pivot_tables.<name>.totals.row` adds a trailing row-total column.
+- `pivot_tables.<name>.totals.row` defines the synthesized trailing row-total column name (it is not required to be a source-table column).
 - `pivot_tables.<name>.totals.column.<name>.mode` supports `sum` and `running_sum` footer rows.
 
 ## Markdown Body Rules

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -32,6 +32,27 @@ report_tables:                       # optional
     columns: [<columnName>, ...]
     cells:
       <columnName>: <expression>
+pivot_tables:                        # optional
+  <pivotName>:
+    source: <tableName>
+    rows:
+      from: <columnName>|<tableName>.<columnName>
+      order: [<value>, ...]          # optional
+    columns:
+      from: <columnName>|<tableName>.<columnName>
+      range:                         # optional
+        start: YYYY-MM-DD
+        end: YYYY-MM-DD
+        step: day|week|month         # optional, default: day
+      label: iso_date|short_month_day  # optional, default: iso_date
+    value: sum(<columnName>)
+    key: <columnName>                # optional, default: source table key
+    empty_cells: null|zero|empty-string|error  # optional, default: null
+    totals:                          # optional
+      row: <columnName>
+      column:
+        <rowName>:
+          mode: sum|running_sum      # optional, default: sum
 ---
 
 # Markdown body (data + presentation)
@@ -53,6 +74,14 @@ report_tables:                       # optional
 - `report_tables.<name>.columns` defines rendered column order.
 - `report_tables.<name>.cells` must define one expression per rendered column.
 - `report_tables.<name>.key` is optional and defaults to the key of the `rows_from` source table.
+- `pivot_tables` defines synthetic 2-D matrices rendered at matching headings.
+- `pivot_tables.<name>.source` must reference an authored table.
+- `pivot_tables.<name>.rows.from` and `.columns.from` accept either a source column name or `table.column` reference to an authored table.
+- `pivot_tables.<name>.columns.range` is optional and requires ISO dates (`YYYY-MM-DD`) with `start <= end`; `step` is `day`, `week`, or `month`.
+- `pivot_tables.<name>.columns.label` supports `iso_date` and `short_month_day`.
+- `pivot_tables.<name>.value` in v1 must be `sum(<column>)` where `<column>` exists in the source table.
+- `pivot_tables.<name>.totals.row` adds a trailing row-total column.
+- `pivot_tables.<name>.totals.column.<name>.mode` supports `sum` and `running_sum` footer rows.
 
 ## Markdown Body Rules
 - Contains only literal values; no inline formulas or expressions.
@@ -60,6 +89,7 @@ report_tables:                       # optional
 - Empty cells adopt `empty_cells` policy.
 - Tables are keyed by the `key` column; key values must be unique per table.
 - A heading whose text matches a `report_tables` name is a render target for that synthetic report table.
+- A heading whose text matches a `pivot_tables` name is a render target for that synthetic pivot table.
 
 ## Data Types
 - Primitive types: `number` (IEEE-754), `string` (UTF-8 text), `bool` (`true`/`false`), `date` (ISO-8601 `YYYY-MM-DD`).
@@ -157,7 +187,8 @@ arguments   ::= expression ( "," expression )*
 4) Evaluate aggregates over final column values.
 5) Evaluate `summary_rows` cell expressions in declaration order.
 6) Evaluate `report_tables` rows from their `rows_from` source tables.
-7) Render outputs (computed columns/summary rows/report tables/interpolation, exports).
+7) Evaluate `pivot_tables` row/column axes, cells, and totals.
+8) Render outputs (computed columns/summary rows/report tables/pivot tables/interpolation, exports).
 
 ### Aggregate Null Handling
 - Aggregates skip null inputs.


### PR DESCRIPTION
## Summary
- update formal spec and format overview with pivot_tables schema and evaluation order
- add worked pivot example under dev/examples
- add VS Code tooling polish for pivot_tables:
  - snippet scaffold
  - schema command now includes tables/report_tables/pivot_tables
  - heading completion/hover for synthetic report/pivot tables
- update work-item checklist for tasks 9 and 10

## Validation
- npm run -w mdxtab test
- npm run -w mdxtab build