### PR TITLE
Issue #38: add pivot_tables support

### DIFF
--- a/dev/examples/pivot-liquidity.md
+++ b/dev/examples/pivot-liquidity.md
@@ -1,0 +1,51 @@
+---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+      order: [Salary, Food, Rent]
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-26
+        step: day
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+    totals:
+      row: total
+      column:
+        accumulated:
+          mode: running_sum
+---
+
+### Explanation
+Builds a synthetic liquidity matrix from event rows. Rows are categories, columns are daily dates, cells are sum(amount), row totals are enabled, and footer row accumulated is a running sum across column totals.
+
+## entries
+
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Salary | 50 |
+| e3 | 2026-04-25 | Food | -30 |
+| e4 | 2026-04-26 | Rent | -40 |
+
+## liquidity
+
+### Expected (rendered)
+- Header contains apr_24, apr_25, apr_26, total.
+- Salary row values are 100, 50, 0 with total 150.
+- Food row values are 0, -30, 0 with total -30.
+- Rent row values are 0, 0, -40 with total -40.
+- Footer row accumulated is 100, 120, 80 with total 300.

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -1,9 +1,9 @@
 # Work Item: Pivot Tables
 
 ## Status
-- State: IN PROGRESS
+- State: DONE
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-docs-tooling` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -209,7 +209,7 @@ synthetically (same model as `report_tables`).
 - PR: https://github.com/Frank-Yong/MDXTab/pull/42
 - Scope: spec/docs updates, examples, optional VS Code/schema/snippet polish.
 - Includes tasks: 9, 10
-- Progress: task 9 docs/spec and task 10 VS Code tooling updates completed.
+- Progress: merged into `issue-38-pivot-tables`.
 
 ### Merge order
 1. `issue-38-pivot-schema-validation`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-render-pipeline` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-docs-tooling` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -169,15 +169,15 @@ synthetically (same model as `report_tables`).
       collisions.
 
 ### 9. Docs & spec
-- [ ] Update `specs/formal-format-spec.md` with the `pivot_tables` schema and
+- [x] Update `specs/formal-format-spec.md` with the `pivot_tables` schema and
       evaluation order entry.
-- [ ] Add `docs/format-overview.md` mention and a worked example under
+- [x] Add `docs/format-overview.md` mention and a worked example under
       `dev/examples/`.
 
 ### 10. Tooling (follow-up, not blocking MVP)
-- [ ] Snippets for `pivot_tables`.
-- [ ] Schema-command output includes `pivot_tables`.
-- [ ] Hover/completion in the VS Code extension.
+- [x] Snippets for `pivot_tables`.
+- [x] Schema-command output includes `pivot_tables`.
+- [x] Hover/completion in the VS Code extension.
 
 ## Sub-branch plan (4 PRs)
 
@@ -202,13 +202,14 @@ synthetically (same model as `report_tables`).
       render injection.
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
-- Progress: render injection for pivot headings completed.
-- Progress: synthetic dependency-order planning hooks added for report/pivot evaluation.
+- Progress: merged into `issue-38-pivot-tables`.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`
+- PR: https://github.com/Frank-Yong/MDXTab/pull/42
 - Scope: spec/docs updates, examples, optional VS Code/schema/snippet polish.
 - Includes tasks: 9, 10
+- Progress: task 9 docs/spec and task 10 VS Code tooling updates completed.
 
 ### Merge order
 1. `issue-38-pivot-schema-validation`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -1,0 +1,240 @@
+# Work Item: Pivot Tables
+
+## Status
+- State: PROPOSED
+- Priority: MEDIUM
+- Branch: `issue-38-pivot-tables` (umbrella only)
+- Issue: https://github.com/Frank-Yong/MDXTab/issues/38
+
+## Description
+Add a `pivot_tables` frontmatter construct that renders a synthetic 2-D matrix
+(rows × columns) sourced from an event table, where the column axis is derived
+from another column or a date range and the cell value is an aggregate. This
+removes the need to hand-author wide pivot tables, per-column `types` lists,
+per-cell expressions, and per-month bookkeeping in user files.
+
+## Background
+
+### Current capabilities
+- `tables` with `key`, `columns`, `types`, `computed`, `aggregates` (incl.
+  `by` grouping), and `summary_rows`.
+- `report_tables`: synthetic tables driven by `rows_from`, with statically
+  declared `columns` and per-column `cells` expressions
+  ([dev/work-items/21-synthetic-report-tables.md](21-synthetic-report-tables.md)).
+
+### What's missing
+A pivot/cross-tab is the natural shape for cash-flow forecasts, time tracking
+by week, and similar matrices. Today every column on the column-axis must be
+declared three times (in `columns`, in `types`, and in `cells`), every cell
+expression must be hand-written, and the data has to be re-pivoted by hand
+each period. Concretely, a 31-day liquidity forecast requires roughly:
+- 31 entries in `columns`
+- 31 entries in `types`
+- 1 long `computed.summary` sum across 31 columns
+- 31 expressions in `summary_rows.accumulated.cells`
+- A 31-row hand-typed `date_index` table
+- A wide markdown table re-typed every month
+
+### Motivating user file
+[Likviditet-2026.05.md](https://github.com/Frank-Yong/Personal/blob/main/Regnskap/Likviditet/2026/202605/Likviditet-2026.05.md)
+(private repo): a monthly cash-flow forecast pivoted as `category × date`,
+where the source data is a flat `likviditet_entries` table of
+`(id, date, category, amount)`. The frontmatter is dominated by date-axis
+boilerplate that should be generated from the source data and a date range.
+
+### Key files (expected impact)
+- `packages/core/src/types.ts` — frontmatter schema additions
+- `packages/core/src/frontmatter.ts` — parse/validate `pivot_tables`
+- `packages/core/src/document.ts` — evaluation phase + render injection
+- `packages/core/src/dependency-graph.ts` — register pivots in eval order
+- `packages/core/src/__tests__/` — integration tests
+- `packages/vscode/syntaxes/`, snippets, schema command — optional follow-up
+
+## Target layout
+
+### Minimum viable pivot
+
+```yaml
+---
+mdxtab: "1.0"
+tables:
+  likviditet_entries:
+    key: id
+    columns: [id, date, category, amount]
+    types: { id: string, date: date, category: string, amount: number }
+pivot_tables:
+  likviditet:
+    source: likviditet_entries
+    rows:
+      from: category                       # distinct values from source.category
+    columns:
+      from: date
+      range: { start: 2026-04-24, end: 2026-05-24, step: day }
+      label: short_month_day               # apr_24, may_01, ...
+    value: sum(amount)                     # aggregator over matching events
+    empty_cells: zero
+    totals:
+      row: summary                         # adds a per-row total column
+      column:                              # adds a footer row
+        accumulated:
+          mode: running_sum                # = self[prev_col] + col_total
+---
+
+# Likviditet 25.04.2026-24.05.2026
+
+## likviditet_entries
+
+| id   | date       | category    | amount   |
+|------|------------|-------------|----------|
+| e001 | 2026-03-25 | Salary      | 51067.66 |
+| ...  | ...        | ...         | ...      |
+
+## likviditet
+```
+
+The `## likviditet` heading is the render target; the body is generated
+synthetically (same model as `report_tables`).
+
+### Optional knobs (deferred unless needed)
+- `rows.from: <table>.<column>` — drive rows from a stable list (e.g.,
+  `categories`) so empty rows still render in deterministic order.
+- `rows.order: [Salary, Mortgage, ...]` — explicit row order.
+- `value: <expr>` — full expression context (`row.<source_col>`,
+  `column.<axis_value>`), defaulting to `sum(amount)`.
+- `columns.from: <table>.<column>` — distinct values from another table.
+- `columns.range.step: week | month` — coarser axes.
+- Column-header formatting: `label: iso_date | short_month_day | <expr>`.
+
+## Tasks
+
+### 1. Design the `pivot_tables` frontmatter schema
+- [ ] Add `pivot_tables` to frontmatter types.
+- [ ] Required fields: `source`, `rows`, `columns`, `value`.
+- [ ] Optional fields: `empty_cells`, `totals`, `key`.
+- [ ] Validate name uniqueness against `tables` and `report_tables`.
+- [ ] Validate `source` references an authored table; `rows.from` and
+      `columns.from` reference real columns or table.column paths.
+- [ ] Diagnostics for missing/invalid fields, unknown identifiers, unsupported
+      `step`, invalid date ranges (`start > end`, non-ISO dates).
+
+### 2. Define column-axis generation
+- [ ] Derive the ordered axis from either:
+  - distinct source-column values (sorted deterministically), or
+  - a `range` over `date` with `step`.
+- [ ] Generate stable header identifiers (must satisfy identifier rules so
+      they can be referenced by `totals` and downstream lookups).
+- [ ] Surface header derivation in compile output for tooling.
+
+### 3. Define row-axis generation
+- [ ] Derive the ordered row list from distinct source values, or from a
+      referenced table column when `rows.from: <table>.<col>` is used.
+- [ ] Preserve declared order when sourced from a table; sort deterministically
+      otherwise.
+
+### 4. Evaluate pivot cells
+- [ ] For each (row, column) pair, evaluate `value` over the subset of
+      `source` rows matching that row key and column-axis value.
+- [ ] Apply `empty_cells` policy when no events match.
+- [ ] Reuse the existing aggregate evaluator; no new functions required for
+      MVP (`sum` only).
+- [ ] Define error behavior consistent with `report_tables` (missing source,
+      type mismatch on axis values, etc.).
+
+### 5. Totals
+- [ ] `totals.row: <name>` adds a synthesized trailing column equal to
+      `sum` across the row's pivot cells.
+- [ ] `totals.column.<name>.mode: sum | running_sum` adds a footer row.
+- [ ] Names must satisfy identifier rules and not collide with axis headers.
+
+### 6. Render injection
+- [ ] Detect `## <pivot_name>` headings and inject the rendered Markdown
+      table (same mechanism as `report_tables`).
+- [ ] Preserve deterministic header and row order.
+- [ ] Source markdown remains unchanged; rendering occurs in preview/output
+      and CLI `render` only.
+
+### 7. Dependency graph & evaluation order
+- [ ] Register pivot tables after row evaluation and aggregates of the source
+      table.
+- [ ] Detect cycles if a pivot is referenced from another pivot or report
+      table (deferred: pivot output is not addressable in expressions in MVP).
+
+### 8. Tests
+- [ ] Unit: axis generation (distinct values, date range, deterministic order).
+- [ ] Unit: cell evaluation with `empty_cells` policies.
+- [ ] Unit: row/column totals (including running sum).
+- [ ] Integration: full compile + render of a `category × date` pivot matching
+      the motivating user file.
+- [ ] Diagnostics: missing source, invalid range, unknown columns, identifier
+      collisions.
+
+### 9. Docs & spec
+- [ ] Update `specs/formal-format-spec.md` with the `pivot_tables` schema and
+      evaluation order entry.
+- [ ] Add `docs/format-overview.md` mention and a worked example under
+      `dev/examples/`.
+
+### 10. Tooling (follow-up, not blocking MVP)
+- [ ] Snippets for `pivot_tables`.
+- [ ] Schema-command output includes `pivot_tables`.
+- [ ] Hover/completion in the VS Code extension.
+
+## Sub-branch plan (4 PRs)
+
+### 1) Schema + validation
+- Branch: `issue-38-pivot-schema-validation`
+- Scope: frontmatter shape, parser validation, and diagnostics.
+- Includes tasks: 1
+- Stretch in same PR if small: diagnostic tests from task 8.
+
+### 2) Axes + cell evaluation + totals
+- Branch: `issue-38-pivot-eval-core`
+- Scope: row/column axis generation, cell aggregation, totals behavior.
+- Includes tasks: 2, 3, 4, 5
+- Tests in same PR: unit tests for axis/cell/totals from task 8.
+
+### 3) Pipeline + rendering
+- Branch: `issue-38-pivot-render-pipeline`
+- Scope: evaluation order integration, dependency graph hooks, heading-based
+      render injection.
+- Includes tasks: 6, 7
+- Tests in same PR: compile/render integration coverage from task 8.
+
+### 4) Docs + examples + tooling polish
+- Branch: `issue-38-pivot-docs-tooling`
+- Scope: spec/docs updates, examples, optional VS Code/schema/snippet polish.
+- Includes tasks: 9, 10
+
+### Merge order
+1. `issue-38-pivot-schema-validation`
+2. `issue-38-pivot-eval-core`
+3. `issue-38-pivot-render-pipeline`
+4. `issue-38-pivot-docs-tooling`
+
+### Notes
+- Keep `issue-38-pivot-tables` as umbrella tracking branch only.
+- Open each PR against `main` to keep review scope focused and parallelizable.
+
+## Out of scope (v1 of this work item)
+- Multiple aggregators per cell.
+- Custom expressions referencing other pivot cells.
+- Non-`sum` aggregators in the cell value (can be added without schema
+  changes).
+- Nested row/column axes (multi-level pivots).
+- Editing the rendered pivot back into source data.
+
+## Acceptance criteria
+- A monthly liquidity file can drop the wide `likviditet` table, the
+  `date_index` table, the per-day `types`, the long `computed.summary`, and
+  the per-day `summary_rows.accumulated.cells` and still render the same
+  category × date matrix with row totals and a running-sum footer.
+- New month: only the `range` (and source events) needs to change.
+
+## Alternatives considered
+- **Multi-key grouped aggregates** (`sum(amount) by category, date`) plus a
+  `report_tables` entry: still requires N hand-written cell expressions for
+  N axis values; does not solve the "awful to recreate every month" problem.
+- **Filtered aggregates** (`sum(amount where ...)`): same downside; also
+  expands the expression language surface.
+- **External pre-generation script**: rejected by user (out of scope for the
+  authoring workflow).

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-render-pipeline` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-docs-tooling` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -202,8 +202,7 @@ synthetically (same model as `report_tables`).
       render injection.
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
-- Progress: render injection for pivot headings completed.
-- Progress: synthetic dependency-order planning hooks added for report/pivot evaluation.
+- Progress: merged into `issue-38-pivot-tables`.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-eval-core` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-render-pipeline` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -193,7 +193,7 @@ synthetically (same model as `report_tables`).
 - Scope: row/column axis generation, cell aggregation, totals behavior.
 - Includes tasks: 2, 3, 4, 5
 - Tests in same PR: unit tests for axis/cell/totals from task 8.
-- Progress: completed in commit `8e2fa0c`.
+- Progress: completed in commit `8e2fa0c`, merged into `issue-38-pivot-tables`.
 
 ### 3) Pipeline + rendering
 - Branch: `issue-38-pivot-render-pipeline`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -3,7 +3,7 @@
 ## Status
 - State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-schema-validation` (active), `issue-38-pivot-tables` (umbrella)
+- Branch: `issue-38-pivot-eval-core` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -118,33 +118,33 @@ synthetically (same model as `report_tables`).
       `step`, invalid date ranges (`start > end`, non-ISO dates).
 
 ### 2. Define column-axis generation
-- [ ] Derive the ordered axis from either:
+- [x] Derive the ordered axis from either:
   - distinct source-column values (sorted deterministically), or
   - a `range` over `date` with `step`.
-- [ ] Generate stable header identifiers (must satisfy identifier rules so
+- [x] Generate stable header identifiers (must satisfy identifier rules so
       they can be referenced by `totals` and downstream lookups).
-- [ ] Surface header derivation in compile output for tooling.
+- [x] Surface header derivation in compile output for tooling.
 
 ### 3. Define row-axis generation
-- [ ] Derive the ordered row list from distinct source values, or from a
+- [x] Derive the ordered row list from distinct source values, or from a
       referenced table column when `rows.from: <table>.<col>` is used.
-- [ ] Preserve declared order when sourced from a table; sort deterministically
+- [x] Preserve declared order when sourced from a table; sort deterministically
       otherwise.
 
 ### 4. Evaluate pivot cells
-- [ ] For each (row, column) pair, evaluate `value` over the subset of
+- [x] For each (row, column) pair, evaluate `value` over the subset of
       `source` rows matching that row key and column-axis value.
-- [ ] Apply `empty_cells` policy when no events match.
-- [ ] Reuse the existing aggregate evaluator; no new functions required for
+- [x] Apply `empty_cells` policy when no events match.
+- [x] Reuse the existing aggregate evaluator; no new functions required for
       MVP (`sum` only).
-- [ ] Define error behavior consistent with `report_tables` (missing source,
+- [x] Define error behavior consistent with `report_tables` (missing source,
       type mismatch on axis values, etc.).
 
 ### 5. Totals
-- [ ] `totals.row: <name>` adds a synthesized trailing column equal to
+- [x] `totals.row: <name>` adds a synthesized trailing column equal to
       `sum` across the row's pivot cells.
-- [ ] `totals.column.<name>.mode: sum | running_sum` adds a footer row.
-- [ ] Names must satisfy identifier rules and not collide with axis headers.
+- [x] `totals.column.<name>.mode: sum | running_sum` adds a footer row.
+- [x] Names must satisfy identifier rules and not collide with axis headers.
 
 ### 6. Render injection
 - [ ] Detect `## <pivot_name>` headings and inject the rendered Markdown
@@ -160,10 +160,10 @@ synthetically (same model as `report_tables`).
       table (deferred: pivot output is not addressable in expressions in MVP).
 
 ### 8. Tests
-- [ ] Unit: axis generation (distinct values, date range, deterministic order).
-- [ ] Unit: cell evaluation with `empty_cells` policies.
-- [ ] Unit: row/column totals (including running sum).
-- [ ] Integration: full compile + render of a `category × date` pivot matching
+- [x] Unit: axis generation (distinct values, date range, deterministic order).
+- [x] Unit: cell evaluation with `empty_cells` policies.
+- [x] Unit: row/column totals (including running sum).
+- [x] Integration: full compile + render of a `category × date` pivot matching
       the motivating user file.
 - [x] Diagnostics: missing source, invalid range, unknown columns, identifier
       collisions.
@@ -193,6 +193,7 @@ synthetically (same model as `report_tables`).
 - Scope: row/column axis generation, cell aggregation, totals behavior.
 - Includes tasks: 2, 3, 4, 5
 - Tests in same PR: unit tests for axis/cell/totals from task 8.
+- Progress: completed in commit `8e2fa0c`.
 
 ### 3) Pipeline + rendering
 - Branch: `issue-38-pivot-render-pipeline`
@@ -214,7 +215,7 @@ synthetically (same model as `report_tables`).
 
 ### Notes
 - Keep `issue-38-pivot-tables` as umbrella tracking branch only.
-- Open each PR against `main` to keep review scope focused and parallelizable.
+- Open each sub-branch PR against `issue-38-pivot-tables` for staged integration.
 
 ## Out of scope (v1 of this work item)
 - Multiple aggregators per cell.

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -1,9 +1,9 @@
 # Work Item: Pivot Tables
 
 ## Status
-- State: PROPOSED
+- State: IN PROGRESS
 - Priority: MEDIUM
-- Branch: `issue-38-pivot-tables` (umbrella only)
+- Branch: `issue-38-pivot-schema-validation` (active), `issue-38-pivot-tables` (umbrella)
 - Issue: https://github.com/Frank-Yong/MDXTab/issues/38
 
 ## Description
@@ -108,13 +108,13 @@ synthetically (same model as `report_tables`).
 ## Tasks
 
 ### 1. Design the `pivot_tables` frontmatter schema
-- [ ] Add `pivot_tables` to frontmatter types.
-- [ ] Required fields: `source`, `rows`, `columns`, `value`.
-- [ ] Optional fields: `empty_cells`, `totals`, `key`.
-- [ ] Validate name uniqueness against `tables` and `report_tables`.
-- [ ] Validate `source` references an authored table; `rows.from` and
+- [x] Add `pivot_tables` to frontmatter types.
+- [x] Required fields: `source`, `rows`, `columns`, `value`.
+- [x] Optional fields: `empty_cells`, `totals`, `key`.
+- [x] Validate name uniqueness against `tables` and `report_tables`.
+- [x] Validate `source` references an authored table; `rows.from` and
       `columns.from` reference real columns or table.column paths.
-- [ ] Diagnostics for missing/invalid fields, unknown identifiers, unsupported
+- [x] Diagnostics for missing/invalid fields, unknown identifiers, unsupported
       `step`, invalid date ranges (`start > end`, non-ISO dates).
 
 ### 2. Define column-axis generation
@@ -165,7 +165,7 @@ synthetically (same model as `report_tables`).
 - [ ] Unit: row/column totals (including running sum).
 - [ ] Integration: full compile + render of a `category × date` pivot matching
       the motivating user file.
-- [ ] Diagnostics: missing source, invalid range, unknown columns, identifier
+- [x] Diagnostics: missing source, invalid range, unknown columns, identifier
       collisions.
 
 ### 9. Docs & spec
@@ -186,6 +186,7 @@ synthetically (same model as `report_tables`).
 - Scope: frontmatter shape, parser validation, and diagnostics.
 - Includes tasks: 1
 - Stretch in same PR if small: diagnostic tests from task 8.
+- Progress: completed in commit `9252d56`.
 
 ### 2) Axes + cell evaluation + totals
 - Branch: `issue-38-pivot-eval-core`

--- a/dev/work-items/28-pivot-tables.md
+++ b/dev/work-items/28-pivot-tables.md
@@ -147,16 +147,16 @@ synthetically (same model as `report_tables`).
 - [x] Names must satisfy identifier rules and not collide with axis headers.
 
 ### 6. Render injection
-- [ ] Detect `## <pivot_name>` headings and inject the rendered Markdown
+- [x] Detect `## <pivot_name>` headings and inject the rendered Markdown
       table (same mechanism as `report_tables`).
-- [ ] Preserve deterministic header and row order.
-- [ ] Source markdown remains unchanged; rendering occurs in preview/output
+- [x] Preserve deterministic header and row order.
+- [x] Source markdown remains unchanged; rendering occurs in preview/output
       and CLI `render` only.
 
 ### 7. Dependency graph & evaluation order
-- [ ] Register pivot tables after row evaluation and aggregates of the source
+- [x] Register pivot tables after row evaluation and aggregates of the source
       table.
-- [ ] Detect cycles if a pivot is referenced from another pivot or report
+- [x] Detect cycles if a pivot is referenced from another pivot or report
       table (deferred: pivot output is not addressable in expressions in MVP).
 
 ### 8. Tests
@@ -197,10 +197,13 @@ synthetically (same model as `report_tables`).
 
 ### 3) Pipeline + rendering
 - Branch: `issue-38-pivot-render-pipeline`
+- PR: https://github.com/Frank-Yong/MDXTab/pull/41
 - Scope: evaluation order integration, dependency graph hooks, heading-based
       render injection.
 - Includes tasks: 6, 7
 - Tests in same PR: compile/render integration coverage from task 8.
+- Progress: render injection for pivot headings completed.
+- Progress: synthetic dependency-order planning hooks added for report/pivot evaluation.
 
 ### 4) Docs + examples + tooling polish
 - Branch: `issue-38-pivot-docs-tooling`

--- a/docs/format-overview.md
+++ b/docs/format-overview.md
@@ -38,12 +38,20 @@ tables:
 - `aggregates`: table-wide results (`sum`, `avg`, `min`, `max`, `count`)
 - `summary_rows`: synthetic footer-style rows
 - `report_tables`: synthetic derived tables rendered at matching headings
+- `pivot_tables`: synthetic matrix tables rendered at matching headings
 
 ## Common expression inputs
 
 - `row.<column>` for current row values
 - aggregate functions like `sum(net)`
 - lookup paths like `transactions.total_by_category[row.id]`
+
+## Pivot tables
+
+- Use `pivot_tables` when you need a matrix layout such as `category x date`.
+- Define `source`, `rows.from`, `columns.from`, and `value`.
+- Optional `columns.range` generates a deterministic date axis (`day`, `week`, `month`).
+- Optional `totals` adds row-total and footer rows.
 
 ## Design rule
 
@@ -55,6 +63,7 @@ Keep formulas in frontmatter and keep markdown tables as data only.
 - `dev/examples/time-entries.md`
 - `dev/examples/grouped-aggregates.md`
 - `dev/examples/transactions.md`
+- `dev/examples/pivot-liquidity.md`
 
 ## Next
 

--- a/packages/core/src/__tests__/dependency-graph.spec.ts
+++ b/packages/core/src/__tests__/dependency-graph.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { lexExpression } from "../tokens.js";
 import { parseExpression } from "../parser.js";
-import { buildDependencyGraph } from "../dependency-graph.js";
+import { buildDependencyGraph, buildNameDependencyGraph } from "../dependency-graph.js";
 
 const ast = (expr: string) => parseExpression(lexExpression(expr));
 
@@ -62,5 +62,23 @@ describe("dependency graph", () => {
 
     expect(graph.edges).toEqual([{ from: "title", to: "role_id" }]);
     expect(graph.order).toEqual(["role_id", "title"]);
+  });
+
+  it("orders name dependencies with external nodes ignored", () => {
+    const graph = buildNameDependencyGraph({
+      "pivot:liquidity": ["table:entries"],
+      "report:overview": ["pivot:liquidity"],
+    });
+
+    expect(graph.order).toEqual(["pivot:liquidity", "report:overview"]);
+  });
+
+  it("detects cycles in name dependencies", () => {
+    expect(() =>
+      buildNameDependencyGraph({
+        "pivot:a": ["report:b"],
+        "report:b": ["pivot:a"],
+      }),
+    ).toThrow(/E_CYCLE/);
   });
 });

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -590,6 +590,42 @@ report_tables:
     expect(result.rendered).not.toContain("## category_balances\n| label |");
   });
 
+  it("injects report tables after fenced blocks closed with longer backtick runs", () => {
+    const reportDoc = `---
+mdxtab: "1.0"
+tables:
+  categories:
+    key: id
+    columns: [id, label]
+report_tables:
+  category_balances:
+    rows_from: categories
+    columns: [label]
+    cells:
+      label: row.label
+---
+
+## categories
+| id | label |
+|----|-------|
+| Utilities | Utilities |
+
+\`\`\`md
+## category_balances
+| label |
+|-------|
+| should-stay-literal |
+\`\`\`\`
+
+## category_balances
+`;
+
+    const result = compileMdxtab(reportDoc);
+
+    expect(result.rendered).toContain("## category_balances\n\n| label |");
+    expect(result.rendered).toContain("should-stay-literal");
+  });
+
   it("ignores inherited object property names when matching report-table headings", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -850,6 +850,43 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("rows.from references unknown column");
   });
 
+  it("returns frontmatter diagnostics when table.column axis references use a non-source column", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+  categories:
+    key: id
+    columns: [id, label]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: categories.label
+    columns:
+      from: date
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+
+## categories
+| id | label |
+|----|-------|
+| Salary | Salary |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("does not exist in source table entries");
+  });
+
   it("returns frontmatter diagnostics when pivot_tables range start is after end", () => {
     const badPivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -680,6 +680,448 @@ report_tables:
     expect(result.rendered).toContain("## __proto__\n\n| label |");
   });
 
+  it("parses pivot_tables with required fields", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.frontmatter.pivot_tables?.liquidity.source).toBe("entries");
+    expect(result.frontmatter.pivot_tables?.liquidity.rows.from).toBe("category");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.from).toBe("date");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.range?.start).toBe("2026-04-24");
+  });
+
+  it("normalizes pivot_tables rows.from and columns.from after validation", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: "  category  "
+    columns:
+      from: "  entries . date  "
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.frontmatter.pivot_tables?.liquidity.rows.from).toBe("category");
+    expect(result.frontmatter.pivot_tables?.liquidity.columns.from).toBe("date");
+  });
+
+  it("returns frontmatter diagnostics when pivot_tables is missing required fields", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    columns:
+      from: date
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("rows is required");
+  });
+
+  it("returns frontmatter diagnostics when pivot_tables source or axis references are invalid", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: missing_col
+    columns:
+      from: date
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("rows.from references unknown column");
+  });
+
+  it("returns frontmatter diagnostics when pivot_tables range start is after end", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-05-24
+        end: 2026-04-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("start must be before or equal");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables range step", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: quarter
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.step must be one of day, week, month");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables empty_cells", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+    empty_cells: nope
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("Invalid empty_cells value");
+  });
+
+  it("returns frontmatter diagnostics for pivot_tables key not in source columns", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    key: missing_key
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("key missing_key is not a column");
+  });
+
+  it("returns frontmatter diagnostics for invalid pivot_tables totals.column mode", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+    totals:
+      column:
+        accumulated:
+          mode: rolling
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].column).toBe("totals.column.accumulated.mode");
+    expect(result.diagnostics[0].message).toContain("totals.column.accumulated.mode must be one of sum, running_sum");
+  });
+
+  it("returns frontmatter diagnostics for non-ISO pivot_tables range start", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-4-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.start must be an ISO date");
+  });
+
+  it("returns frontmatter diagnostics for non-ISO pivot_tables range end", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-5-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.range.end must be an ISO date");
+  });
+
+  it("accepts pivot_tables date ranges with years below 0100", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 0099-01-01
+        end: 0099-01-02
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(pivotDoc);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not fail when a manual markdown table exists under a pivot heading", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-05-24
+        step: day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+
+## liquidity
+| stale | old |
+|-------|-----|
+| 1     | 2   |
+`;
+
+    const validation = validateMdxtab(pivotDoc);
+    expect(validation.diagnostics).toHaveLength(0);
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.rendered).toContain("## liquidity");
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1344,6 +1344,56 @@ pivot_tables:
     expect(pivot.rows[2].values[c0]).toBe(-30);
   });
 
+  it("sorts numeric pivot row and column axes numerically", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, row_bucket, col_bucket, amount]
+    types:
+      row_bucket: number
+      col_bucket: number
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: row_bucket
+    columns:
+      from: col_bucket
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | row_bucket | col_bucket | amount |
+|----|------------|------------|--------|
+| e1 | 10 | 10 | 100 |
+| e2 | 2 | 2 | 20 |
+| e3 | 1 | 1 | 10 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+    const c1 = pivot.columnAxis[1].id;
+    const c2 = pivot.columnAxis[2].id;
+
+    expect(pivot.rowAxis.map((r) => r.key)).toEqual([1, 2, 10]);
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual([1, 2, 10]);
+
+    expect(pivot.rows[0].values[c0]).toBe(10);
+    expect(pivot.rows[0].values[c1]).toBe(0);
+    expect(pivot.rows[0].values[c2]).toBe(0);
+    expect(pivot.rows[1].values[c0]).toBe(0);
+    expect(pivot.rows[1].values[c1]).toBe(20);
+    expect(pivot.rows[1].values[c2]).toBe(0);
+    expect(pivot.rows[2].values[c0]).toBe(0);
+    expect(pivot.rows[2].values[c1]).toBe(0);
+    expect(pivot.rows[2].values[c2]).toBe(100);
+  });
+
   it("generates month-stepped pivot columns with clamped month-end progression", () => {
     const pivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1046,10 +1046,10 @@ pivot_tables:
 `;
 
     const result = validateMdxtab(badPivotDoc);
-  expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(0);
 
-  const compiled = compileMdxtab(badPivotDoc);
-  expect(compiled.pivotTables.liquidity.rows).toHaveLength(1);
+    const compiled = compileMdxtab(badPivotDoc);
+    expect(compiled.pivotTables.liquidity.rows).toHaveLength(1);
   });
 
   it("returns frontmatter diagnostics for invalid pivot_tables totals.column mode", () => {

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -950,7 +950,7 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("Invalid empty_cells value");
   });
 
-  it("returns frontmatter diagnostics for pivot_tables key not in source columns", () => {
+  it("ignores pivot_tables key when provided", () => {
     const badPivotDoc = `---
 mdxtab: "1.0"
 tables:
@@ -979,9 +979,10 @@ pivot_tables:
 `;
 
     const result = validateMdxtab(badPivotDoc);
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
-    expect(result.diagnostics[0].message).toContain("key missing_key is not a column");
+  expect(result.diagnostics).toHaveLength(0);
+
+  const compiled = compileMdxtab(badPivotDoc);
+  expect(compiled.pivotTables.liquidity.rows).toHaveLength(1);
   });
 
   it("returns frontmatter diagnostics for invalid pivot_tables totals.column mode", () => {

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -987,6 +987,36 @@ pivot_tables:
     expect(result.diagnostics[0].message).toContain("Invalid empty_cells value");
   });
 
+  it("returns frontmatter diagnostics for invalid pivot_tables columns.label", () => {
+    const badPivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: month_day
+    value: sum(amount)
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(badPivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_FRONTMATTER");
+    expect(result.diagnostics[0].message).toContain("columns.label must be one of iso_date, short_month_day");
+  });
+
   it("ignores pivot_tables key when provided", () => {
     const badPivotDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1122,6 +1122,330 @@ pivot_tables:
     expect(result.rendered).toContain("## liquidity");
   });
 
+  it("evaluates pivot tables with range columns, row totals, and running footer", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+      order: [Salary, Food]
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-25
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+    totals:
+      row: summary
+      column:
+        accumulated:
+          mode: running_sum
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Salary | 50 |
+| e3 | 2026-04-25 | Food | -30 |
+| e4 | 2026-04-25 | Salary | 20 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+    const c1 = pivot.columnAxis[1].id;
+
+    expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Salary", "Food"]);
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
+
+    expect(pivot.rows[0].values[c0]).toBe(150);
+    expect(pivot.rows[0].values[c1]).toBe(20);
+    expect(pivot.rows[0].total).toBe(170);
+
+    expect(pivot.rows[1].values[c0]).toBe(0);
+    expect(pivot.rows[1].values[c1]).toBe(-30);
+    expect(pivot.rows[1].total).toBe(-30);
+
+    expect(pivot.footerRows?.[0].key).toBe("accumulated");
+    expect(pivot.footerRows?.[0].values[c0]).toBe(150);
+    expect(pivot.footerRows?.[0].values[c1]).toBe(140);
+    expect(pivot.footerRows?.[0].total).toBe(290);
+  });
+
+  it("derives pivot row axis from another table in authored order", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  categories:
+    key: id
+    columns: [id, category]
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: categories.category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-24
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## categories
+| id | category |
+|----|----------|
+| c1 | Travel |
+| c2 | Salary |
+| c3 | Food |
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Food | -30 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+
+    expect(pivot.rowAxis.map((r) => r.key)).toEqual(["Travel", "Salary", "Food"]);
+    expect(pivot.rows[0].values[c0]).toBe(0);
+    expect(pivot.rows[1].values[c0]).toBe(100);
+    expect(pivot.rows[2].values[c0]).toBe(-30);
+  });
+
+  it("generates month-stepped pivot columns with clamped month-end progression", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-01-31
+        end: 2026-03-31
+        step: month
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-01-31 | Salary | 100 |
+| e2 | 2026-02-28 | Salary | 110 |
+| e3 | 2026-03-28 | Salary | 120 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const c0 = pivot.columnAxis[0].id;
+    const c1 = pivot.columnAxis[1].id;
+    const c2 = pivot.columnAxis[2].id;
+
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-01-31", "2026-02-28", "2026-03-28"]);
+    expect(pivot.rows[0].values[c0]).toBe(100);
+    expect(pivot.rows[0].values[c1]).toBe(110);
+    expect(pivot.rows[0].values[c2]).toBe(120);
+  });
+
+  it("applies pivot.columns.label when generating column axis labels", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+      range:
+        start: 2026-04-24
+        end: 2026-04-25
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Salary | 200 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
+    expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
+  });
+
+  it("throws when short_month_day receives a calendar-invalid ISO date key", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-13-10 | Salary | 100 |
+`;
+
+    expect(() => compileMdxtab(pivotDoc)).toThrow(/short_month_day requires ISO date keys/);
+  });
+
+  it("generates identifier-safe, unique pivot axis ids", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-26
+        step: day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+| e2 | 2026-04-25 | Food | -30 |
+| e3 | 2026-04-26 | Travel Expense | -10 |
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    const pivot = result.pivotTables.liquidity;
+    const axisIdRe = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+    for (const entry of pivot.rowAxis) {
+      expect(entry.id).toMatch(axisIdRe);
+    }
+    for (const entry of pivot.columnAxis) {
+      expect(entry.id).toMatch(axisIdRe);
+    }
+
+    const rowIdSet = new Set(pivot.rowAxis.map((entry) => entry.id));
+    const colIdSet = new Set(pivot.columnAxis.map((entry) => entry.id));
+    expect(rowIdSet.size).toBe(pivot.rowAxis.length);
+    expect(colIdSet.size).toBe(pivot.columnAxis.length);
+  });
+
+  it("returns contextual diagnostics for runtime pivot empty_cells errors", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  categories:
+    key: id
+    columns: [id, category]
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: categories.category
+    columns:
+      from: date
+      range:
+        start: 2026-04-24
+        end: 2026-04-24
+        step: day
+    value: sum(amount)
+    empty_cells: error
+---
+
+## categories
+| id | category |
+|----|----------|
+| c1 | Travel |
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2026-04-24 | Salary | 100 |
+`;
+
+    const result = validateMdxtab(pivotDoc);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("E_EMPTY_CELL");
+    expect(result.diagnostics[0].table).toBe("liquidity");
+    expect(result.diagnostics[0].column).toBe("empty_cells");
+    expect(result.diagnostics[0].rowKey).toBe("Travel");
+    expect(result.diagnostics[0].message).toContain("[pivot-table]");
+  });
+
   it("does not remove prose after an existing report table when the prose contains pipes", () => {
     const reportDoc = `---
 mdxtab: "1.0"

--- a/packages/core/src/__tests__/document.spec.ts
+++ b/packages/core/src/__tests__/document.spec.ts
@@ -1083,7 +1083,7 @@ pivot_tables:
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("does not fail when a manual markdown table exists under a pivot heading", () => {
+  it("replaces a manual markdown table under a pivot heading with rendered pivot output", () => {
     const pivotDoc = `---
 mdxtab: "1.0"
 tables:
@@ -1099,9 +1099,10 @@ pivot_tables:
       from: date
       range:
         start: 2026-04-24
-        end: 2026-05-24
+        end: 2026-04-25
         step: day
     value: sum(amount)
+    empty_cells: zero
 ---
 
 ## entries
@@ -1120,6 +1121,9 @@ pivot_tables:
 
     const result = compileMdxtab(pivotDoc);
     expect(result.rendered).toContain("## liquidity");
+    expect(result.rendered).toContain("| category | 2026-04-24 | 2026-04-25 |");
+    expect(result.rendered).toContain("| Salary | 100 | 0 |");
+    expect(result.rendered).not.toContain("| stale | old |");
   });
 
   it("evaluates pivot tables with range columns, row totals, and running footer", () => {
@@ -1318,6 +1322,42 @@ pivot_tables:
     const pivot = result.pivotTables.liquidity;
     expect(pivot.columnAxis.map((c) => c.key)).toEqual(["2026-04-24", "2026-04-25"]);
     expect(pivot.columnAxis.map((c) => c.label)).toEqual(["apr_24", "apr_25"]);
+  });
+
+  it("renders pivot rows correctly when column labels collide", () => {
+    const pivotDoc = `---
+mdxtab: "1.0"
+tables:
+  entries:
+    key: id
+    columns: [id, date, category, amount]
+    types:
+      date: date
+      amount: number
+pivot_tables:
+  liquidity:
+    source: entries
+    rows:
+      from: category
+    columns:
+      from: date
+      label: short_month_day
+    value: sum(amount)
+    empty_cells: zero
+---
+
+## entries
+| id | date | category | amount |
+|----|------|----------|--------|
+| e1 | 2025-04-24 | Salary | 100 |
+| e2 | 2026-04-24 | Salary | 200 |
+
+## liquidity
+`;
+
+    const result = compileMdxtab(pivotDoc);
+    expect(result.rendered).toContain("| category | apr_24 | apr_24 |");
+    expect(result.rendered).toContain("| Salary | 100 | 200 |");
   });
 
   it("throws when short_month_day receives a calendar-invalid ISO date key", () => {

--- a/packages/core/src/date-utils.ts
+++ b/packages/core/src/date-utils.ts
@@ -1,0 +1,18 @@
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_RE.test(value)) return false;
+
+  const [yearRaw, monthRaw, dayRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}

--- a/packages/core/src/dependency-graph.ts
+++ b/packages/core/src/dependency-graph.ts
@@ -12,6 +12,55 @@ export interface DependencyGraph {
   order: string[];
 }
 
+export function buildNameDependencyGraph(
+  nodes: Record<string, string[]>,
+  limits: ExpressionLimits = DEFAULT_EXPRESSION_LIMITS,
+): DependencyGraph {
+  const names = Object.keys(nodes);
+  const nameSet = new Set(names);
+  const edges: DependencyEdge[] = [];
+  const depMap: Record<string, Set<string>> = {};
+
+  for (const [name, deps] of Object.entries(nodes)) {
+    const depSet = new Set<string>(deps);
+    depMap[name] = depSet;
+    for (const dep of depSet) {
+      edges.push({ from: name, to: dep });
+    }
+  }
+
+  const order: string[] = [];
+  const state: Record<string, "visiting" | "visited"> = {};
+
+  const visit = (name: string, depth = 1) => {
+    try {
+      assertDependencyDepth(depth, limits);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`${message} while visiting ${name}`);
+    }
+
+    if (state[name] === "visited") return;
+    if (state[name] === "visiting") {
+      throw new Error(`E_CYCLE: dependency cycle involving ${name}`);
+    }
+
+    state[name] = "visiting";
+    for (const dep of depMap[name] ?? []) {
+      if (!nameSet.has(dep)) continue;
+      visit(dep, depth + 1);
+    }
+    state[name] = "visited";
+    order.push(name);
+  };
+
+  for (const name of names) {
+    visit(name);
+  }
+
+  return { edges, order };
+}
+
 export function buildDependencyGraph(
   nodes: Record<string, AstNode>,
   limits: ExpressionLimits = DEFAULT_EXPRESSION_LIMITS,

--- a/packages/core/src/dependency-graph.ts
+++ b/packages/core/src/dependency-graph.ts
@@ -19,7 +19,7 @@ export function buildNameDependencyGraph(
   const names = Object.keys(nodes);
   const nameSet = new Set(names);
   const edges: DependencyEdge[] = [];
-  const depMap: Record<string, Set<string>> = {};
+  const depMap = Object.create(null) as Record<string, Set<string>>;
 
   for (const [name, deps] of Object.entries(nodes)) {
     const depSet = new Set<string>(deps);
@@ -30,7 +30,7 @@ export function buildNameDependencyGraph(
   }
 
   const order: string[] = [];
-  const state: Record<string, "visiting" | "visited"> = {};
+  const state = Object.create(null) as Record<string, "visiting" | "visited">;
 
   const visit = (name: string, depth = 1) => {
     try {
@@ -122,7 +122,7 @@ export function buildDependencyGraph(
   };
 
   const edges: DependencyEdge[] = [];
-  const depMap: Record<string, Set<string>> = {};
+  const depMap = Object.create(null) as Record<string, Set<string>>;
 
   for (const [name, ast] of Object.entries(nodes)) {
     const deps = new Set<string>();
@@ -134,7 +134,7 @@ export function buildDependencyGraph(
   }
 
   const order: string[] = [];
-  const state: Record<string, "visiting" | "visited"> = {};
+  const state = Object.create(null) as Record<string, "visiting" | "visited">;
 
   const visit = (n: string, depth = 1) => {
     try {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -529,7 +529,7 @@ function getFencedLines(lines: string[]): Set<number> {
   for (let i = 0; i < lines.length; i++) {
     if (inFence) {
       fencedLines.add(i);
-      const closeRe = new RegExp(`^\\s*` + "`".repeat(fenceTicks) + `\\s*$`);
+      const closeRe = new RegExp(`^\\s*` + "`" + `{${fenceTicks},}\\s*$`);
       if (closeRe.test(lines[i])) {
         inFence = false;
         fenceTicks = 0;

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -13,6 +13,8 @@ import type {
   ExpressionLimits,
   FrontmatterDocument,
   ParsedTable,
+  PivotTableDefinition,
+  PivotTableEvaluation,
   ReportTableDefinition,
   ReportTableEvaluation,
   Scalar,
@@ -25,6 +27,7 @@ import type {
 const NUMERIC_RE = /^-?\d+(?:\.\d+)?$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_RE = /^\d+:\d{2}$/;
+const SHORT_MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"] as const;
 
 type ColumnType = "number" | "string" | "date" | "bool" | "time" | undefined;
 type LookupRowFn = (table: string, key: Scalar) => Record<string, Scalar>;
@@ -33,7 +36,7 @@ interface EvalRowContext {
   [key: string]: Scalar | EvalRowContext;
 }
 
-type EvalKind = "computed" | "aggregate" | "summary-row" | "report-table";
+type EvalKind = "computed" | "aggregate" | "summary-row" | "report-table" | "pivot-table";
 
 type GroupedAggregate = {
   fn: string;
@@ -104,6 +107,28 @@ function splitFrontmatter(raw: string): { frontmatter: string; body: string; bod
   const frontmatter = lines.slice(0, endIndex + 1).join("\n");
   const body = lines.slice(endIndex + 1).join("\n");
   return { frontmatter, body, bodyOffset: endIndex + 1 };
+}
+
+function scalarIdentity(value: Scalar): string {
+  if (value === null) return "null:null";
+  return `${typeof value}:${String(value)}`;
+}
+
+function stableHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+function scalarIdentifier(value: Scalar): string {
+  const typeName = value === null ? "null" : typeof value;
+  let slug = String(value).replace(/[^A-Za-z0-9_]/g, "_");
+  if (slug.length === 0) slug = "_";
+  if (!/^[A-Za-z_]/.test(slug)) slug = `_${slug}`;
+  return `k_${typeName}_${slug}_${stableHash(scalarIdentity(value))}`;
 }
 
 function coerceValue(text: string, type: ColumnType): Scalar {
@@ -829,6 +854,438 @@ function evaluateReportTables(
   return results;
 }
 
+function parseColumnReference(sourceTable: string, reference: string): { table: string; column: string } {
+  if (!reference.includes(".")) {
+    return { table: sourceTable, column: reference };
+  }
+  const [table, column] = reference.split(".");
+  return { table, column };
+}
+
+function uniqueByString(values: Scalar[]): Scalar[] {
+  const seen = new Set<string>();
+  const out: Scalar[] = [];
+  for (const value of values) {
+    if (value === null || value === undefined) continue;
+    const key = scalarIdentity(value);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(value);
+  }
+  return out;
+}
+
+function compareByString(a: Scalar, b: Scalar): number {
+  const left = String(a);
+  const right = String(b);
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function applyRowOrdering(values: Scalar[], order: string[] | undefined): Scalar[] {
+  if (!order || order.length === 0) return values;
+  const remaining = [...values];
+  const remainingByKey = new Map<string, Scalar>(remaining.map((value) => [scalarIdentity(value), value]));
+  const ordered: Scalar[] = [];
+
+  for (const orderedValue of order) {
+    const key = scalarIdentity(orderedValue);
+    if (!remainingByKey.has(key)) continue;
+    ordered.push(remainingByKey.get(key)!);
+    remainingByKey.delete(key);
+  }
+
+  for (const value of remaining) {
+    const key = scalarIdentity(value);
+    if (!remainingByKey.has(key)) continue;
+    ordered.push(value);
+    remainingByKey.delete(key);
+  }
+
+  return ordered;
+}
+
+function parsePivotValueColumn(
+  pivotName: string,
+  source: string,
+  sourceSchema: TableFrontmatter,
+  expression: string,
+): string {
+  const match = expression.trim().match(/^sum\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)$/i);
+  if (!match) {
+    throw new DiagnosticError({
+      code: "E_FRONTMATTER",
+      message: `pivot_table ${pivotName} value must be sum(<column>) in v1`,
+      table: pivotName,
+      column: "value",
+      range: lineRange(0),
+    });
+  }
+  const column = match[1];
+  if (!sourceSchema.columns.includes(column)) {
+    throw new DiagnosticError({
+      code: "E_FRONTMATTER",
+      message: `pivot_table ${pivotName} value references unknown column ${column} in source table ${source}`,
+      table: pivotName,
+      column: "value",
+      range: lineRange(0),
+    });
+  }
+  return column;
+}
+
+function parseIsoDatePreserveYear(isoDate: string): Date {
+  const [yearText, monthText, dayText] = isoDate.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const date = new Date(Date.UTC(0, 0, 1));
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function isValidIsoDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const [yearText, monthText, dayText] = value.split("-");
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
+function formatIsoDate(date: Date): string {
+  const year = String(date.getUTCFullYear()).padStart(4, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function daysInUtcMonth(year: number, monthIndexZeroBased: number): number {
+  return new Date(Date.UTC(year, monthIndexZeroBased + 1, 0)).getUTCDate();
+}
+
+function addUtcMonthsClamped(date: Date, months: number): Date {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+
+  const rawTargetMonth = month + months;
+  const targetYear = year + Math.floor(rawTargetMonth / 12);
+  const targetMonth = ((rawTargetMonth % 12) + 12) % 12;
+  const clampedDay = Math.min(day, daysInUtcMonth(targetYear, targetMonth));
+
+  const next = new Date(Date.UTC(0, 0, 1));
+  next.setUTCFullYear(targetYear, targetMonth, clampedDay);
+  next.setUTCHours(0, 0, 0, 0);
+  return next;
+}
+
+function derivePivotColumnLabel(
+  pivotName: string,
+  key: Scalar,
+  labelMode: string | undefined,
+): string {
+  const raw = String(key);
+  if (!labelMode || labelMode === "iso_date") return raw;
+
+  if (labelMode === "short_month_day") {
+    if (!isValidIsoDate(raw)) {
+      throw new DiagnosticError({
+        code: "E_FRONTMATTER",
+        message: `pivot_table ${pivotName} columns.label short_month_day requires ISO date keys`,
+        table: pivotName,
+        column: "columns.label",
+        range: lineRange(0),
+      });
+    }
+    const [, monthText, dayText] = raw.split("-");
+    const month = Number(monthText);
+    return `${SHORT_MONTHS[month - 1]}_${dayText}`;
+  }
+
+  throw new DiagnosticError({
+    code: "E_FRONTMATTER",
+    message: `pivot_table ${pivotName} columns.label must be one of iso_date, short_month_day`,
+    table: pivotName,
+    column: "columns.label",
+    range: lineRange(0),
+  });
+}
+
+function buildDateRangeValues(
+  pivotName: string,
+  start: string,
+  end: string,
+  step: "day" | "week" | "month",
+): Scalar[] {
+  const values: Scalar[] = [];
+  let current = parseIsoDatePreserveYear(start);
+  const endDate = parseIsoDatePreserveYear(end);
+
+  let guard = 0;
+  while (current.getTime() <= endDate.getTime()) {
+    values.push(formatIsoDate(current));
+
+    const before = current.getTime();
+    if (step === "day") current.setUTCDate(current.getUTCDate() + 1);
+    else if (step === "week") current.setUTCDate(current.getUTCDate() + 7);
+    else current = addUtcMonthsClamped(current, 1);
+
+    if (current.getTime() <= before) {
+      throw new DiagnosticError({
+        code: "E_RANGE",
+        message: `pivot_table ${pivotName} has invalid date range increment`,
+        table: pivotName,
+        column: "columns.range",
+        range: lineRange(0),
+      });
+    }
+    guard += 1;
+    if (guard > 100000) {
+      throw new DiagnosticError({
+        code: "E_LIMIT",
+        message: `pivot_table ${pivotName} date range is too large`,
+        table: pivotName,
+        column: "columns.range",
+        range: lineRange(0),
+      });
+    }
+  }
+
+  return values;
+}
+
+function emptyPivotCell(policy: PivotTableDefinition["empty_cells"] | undefined): Scalar {
+  switch (policy ?? "null") {
+    case "null":
+      return null;
+    case "zero":
+      return 0;
+    case "empty-string":
+      return "";
+    case "error":
+      throw new Error("E_EMPTY_CELL: no matching source rows for pivot cell");
+    default:
+      return null;
+  }
+}
+
+function toNumericOrNull(value: Scalar): Scalar {
+  return typeof value === "number" ? value : null;
+}
+
+function toPivotDiagnostic(
+  err: unknown,
+  info: { table: string; rowKey?: string; column?: string; messagePrefix: string },
+): DiagnosticError {
+  if (err instanceof DiagnosticError) {
+    return new DiagnosticError({
+      code: err.code,
+      message: `${info.messagePrefix}: ${err.message}`,
+      severity: err.severity,
+      table: err.table ?? info.table,
+      column: err.column ?? info.column,
+      rowKey: err.rowKey ?? info.rowKey,
+      range: err.range,
+    });
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new DiagnosticError({
+    code: errorCodeFromMessage(message),
+    message: `${info.messagePrefix}: ${message}`,
+    table: info.table,
+    column: info.column,
+    rowKey: info.rowKey,
+  });
+}
+
+function evaluatePivotTables(
+  pivotTables: Record<string, PivotTableDefinition> | undefined,
+  schemas: Record<string, TableFrontmatter>,
+  rowList: Record<string, Record<string, Scalar>[]>,
+  ensureByTable: Record<string, (row: Record<string, Scalar>) => Record<string, Scalar>>,
+): Record<string, PivotTableEvaluation> {
+  if (!pivotTables) return Object.create(null) as Record<string, PivotTableEvaluation>;
+
+  const results = Object.create(null) as Record<string, PivotTableEvaluation>;
+
+  for (const [name, pivot] of Object.entries(pivotTables)) {
+    const sourceRows = rowList[pivot.source] ?? [];
+    const ensureSource = ensureByTable[pivot.source];
+    const sourceSchema = schemas[pivot.source];
+
+    const rowRef = parseColumnReference(pivot.source, pivot.rows.from);
+    const columnRef = parseColumnReference(pivot.source, pivot.columns.from);
+    const valueColumn = parsePivotValueColumn(name, pivot.source, sourceSchema, pivot.value);
+
+    const rowAxisSourceRows = rowList[rowRef.table] ?? [];
+    const ensureRowAxisTable = ensureByTable[rowRef.table];
+    let rowValues = uniqueByString(rowAxisSourceRows.map((row) => ensureRowAxisTable(row)[rowRef.column]));
+    if (rowRef.table === pivot.source) {
+      rowValues = [...rowValues].sort(compareByString);
+    }
+    rowValues = applyRowOrdering(rowValues, pivot.rows.order);
+
+    const columnAxisSourceRows = rowList[columnRef.table] ?? [];
+    const ensureColumnAxisTable = ensureByTable[columnRef.table];
+    let columnValues: Scalar[];
+    if (pivot.columns.range) {
+      columnValues = buildDateRangeValues(
+        name,
+        pivot.columns.range.start,
+        pivot.columns.range.end,
+        pivot.columns.range.step ?? "day",
+      );
+    } else {
+      columnValues = uniqueByString(columnAxisSourceRows.map((row) => ensureColumnAxisTable(row)[columnRef.column]));
+      columnValues = [...columnValues].sort(compareByString);
+    }
+
+    const rowAxis = rowValues.map((key, index) => ({ id: scalarIdentifier(key), key, label: String(key), index }));
+    const columnAxis = columnValues.map((key, index) => ({
+      id: scalarIdentifier(key),
+      key,
+      label: derivePivotColumnLabel(name, key, pivot.columns.label),
+      index,
+    }));
+
+    const ensuredSourceRows = sourceRows.map((row) => ensureSource(row));
+    const rowAxisIdByIdentity = new Map<string, string>(rowAxis.map((entry) => [scalarIdentity(entry.key), entry.id]));
+    const columnAxisIdByIdentity = new Map<string, string>(
+      columnAxis.map((entry) => [scalarIdentity(entry.key), entry.id]),
+    );
+    const pairValueBuckets = new Map<string, Scalar[]>();
+    const pairDisplayKeys = new Map<string, { row: string; column: string }>();
+    const pairKey = (rowId: string, columnId: string) => `${rowId}\u0000${columnId}`;
+
+    for (const row of ensuredSourceRows) {
+      const rowKey = row[rowRef.column];
+      const colKey = row[columnRef.column];
+      if (rowKey === null || rowKey === undefined || colKey === null || colKey === undefined) {
+        continue;
+      }
+      const rowId = rowAxisIdByIdentity.get(scalarIdentity(rowKey));
+      const columnId = columnAxisIdByIdentity.get(scalarIdentity(colKey));
+      if (!rowId || !columnId) {
+        continue;
+      }
+      const key = pairKey(rowId, columnId);
+      const bucket = pairValueBuckets.get(key);
+      if (bucket) {
+        bucket.push(row[valueColumn]);
+      } else {
+        pairValueBuckets.set(key, [row[valueColumn]]);
+        pairDisplayKeys.set(key, { row: String(rowKey), column: String(colKey) });
+      }
+    }
+
+    const pairAggregates = new Map<string, Scalar>();
+    for (const [key, values] of pairValueBuckets.entries()) {
+      try {
+        pairAggregates.set(key, computeAggregateValues("sum", values));
+      } catch (err) {
+        const display = pairDisplayKeys.get(key) ?? { row: "<unknown>", column: "<unknown>" };
+        throw toPivotDiagnostic(err, {
+          table: name,
+          rowKey: display.row,
+          column: display.column,
+          messagePrefix: `[pivot-table] table ${name} cell row=${display.row} column=${display.column}`,
+        });
+      }
+    }
+
+    const evaluatedRows = rowAxis.map((rowAxisEntry) => {
+      const values = Object.create(null) as Record<string, Scalar>;
+
+      for (const columnAxisEntry of columnAxis) {
+        const key = pairKey(rowAxisEntry.id, columnAxisEntry.id);
+        if (!pairValueBuckets.has(key)) {
+          try {
+            values[columnAxisEntry.id] = emptyPivotCell(pivot.empty_cells);
+          } catch (err) {
+            throw toPivotDiagnostic(err, {
+              table: name,
+              rowKey: String(rowAxisEntry.key),
+              column: "empty_cells",
+              messagePrefix: `[pivot-table] table ${name} cell row=${String(rowAxisEntry.key)} column=${columnAxisEntry.label}`,
+            });
+          }
+          continue;
+        }
+        values[columnAxisEntry.id] = pairAggregates.get(key) ?? 0;
+      }
+
+      const rowTotal = pivot.totals?.row
+        ? computeAggregateValues("sum", Object.values(values).map(toNumericOrNull))
+        : undefined;
+
+      return {
+        key: rowAxisEntry.key,
+        values,
+        total: rowTotal,
+      };
+    });
+
+    let footerRows: PivotTableEvaluation["footerRows"];
+    if (pivot.totals?.column) {
+      footerRows = [];
+      for (const [footerName, footerDef] of Object.entries(pivot.totals.column)) {
+        const mode = footerDef.mode ?? "sum";
+        const footerValues = Object.create(null) as Record<string, Scalar>;
+        let running = 0;
+        for (const columnAxisEntry of columnAxis) {
+          const colTotal = computeAggregateValues(
+            "sum",
+            evaluatedRows.map((row) => toNumericOrNull(row.values[columnAxisEntry.id])),
+          );
+
+          if (mode === "running_sum") {
+            const numericColTotal = typeof colTotal === "number" ? colTotal : 0;
+            running += numericColTotal;
+            footerValues[columnAxisEntry.id] = running;
+          } else {
+            footerValues[columnAxisEntry.id] = colTotal;
+          }
+        }
+
+        const footerTotal = pivot.totals.row
+          ? computeAggregateValues("sum", Object.values(footerValues).map(toNumericOrNull))
+          : undefined;
+
+        footerRows.push({
+          key: footerName,
+          mode,
+          values: footerValues,
+          total: footerTotal,
+        });
+      }
+    }
+
+    results[name] = {
+      name,
+      source: pivot.source,
+      rowsFrom: pivot.rows.from,
+      columnsFrom: pivot.columns.from,
+      value: pivot.value,
+      rowAxis,
+      columnAxis,
+      rows: evaluatedRows,
+      rowTotalName: pivot.totals?.row,
+      footerRows,
+    };
+  }
+
+  return results;
+}
+
 function interpolateAggregates(
   body: string,
   aggregates: Record<string, Record<string, Scalar>>,
@@ -1210,6 +1667,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     groupedAggregateResults,
     limits,
   );
+  const pivotTableResults = evaluatePivotTables(frontmatter.pivot_tables, frontmatter.tables, rowList, ensureByTable);
 
   const results = Object.create(null) as Record<string, TableEvaluation>;
   for (const [name, rows] of Object.entries(rowList)) {
@@ -1256,6 +1714,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     frontmatter: frontmatter as FrontmatterDocument,
     tables: results,
     reportTables: reportTableResults,
+    pivotTables: pivotTableResults,
     rendered,
   };
 }

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -972,10 +972,11 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
 
   const schemaNames = new Set(Object.keys(frontmatter.tables));
   const reportTableNames = new Set(Object.keys(frontmatter.report_tables ?? {}));
+  const pivotTableNames = new Set(Object.keys(frontmatter.pivot_tables ?? {}));
   const tableByName = Object.create(null) as Record<string, ParsedTable>;
   for (const t of tables) {
     if (!schemaNames.has(t.name)) {
-      if (reportTableNames.has(t.name)) {
+      if (reportTableNames.has(t.name) || pivotTableNames.has(t.name)) {
         continue;
       }
       throw new DiagnosticError({

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1096,7 +1096,7 @@ function addUtcMonthsClamped(date: Date, months: number): Date {
 function derivePivotColumnLabel(
   pivotName: string,
   key: Scalar,
-  labelMode: string | undefined,
+  labelMode: PivotTableDefinition["columns"]["label"],
 ): string {
   const raw = String(key);
   if (!labelMode || labelMode === "iso_date") return raw;

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1,4 +1,4 @@
-import { buildDependencyGraph } from "./dependency-graph.js";
+import { buildDependencyGraph, buildNameDependencyGraph } from "./dependency-graph.js";
 import { evaluateAst } from "./evaluator.js";
 import { parseExpression, type AstNode } from "./parser.js";
 import { parseFrontmatter } from "./frontmatter.js";
@@ -733,6 +733,48 @@ function renderMarkdownTable(columns: string[], rows: Record<string, Scalar>[]):
   return [header, separator, ...dataLines];
 }
 
+function renderMarkdownTableFromMatrix(headers: string[], rows: Scalar[][]): string[] {
+  const headerCells = headers.map((header) => formatScalar(header));
+  const header = `| ${headerCells.join(" | ")} |`;
+  const separator = `|${headerCells.map((cell) => "-".repeat(Math.max(cell.length + 2, 3))).join("|")}|`;
+  const dataLines = rows.map((cells) => `| ${cells.map((cell) => formatScalar(cell)).join(" | ")} |`);
+  return [header, separator, ...dataLines];
+}
+
+function renderPivotMarkdownTable(pivot: PivotTableEvaluation): string[] {
+  const columns = [pivot.rowsFrom, ...pivot.columnAxis.map((entry) => entry.label)];
+  if (pivot.rowTotalName) {
+    columns.push(pivot.rowTotalName);
+  }
+
+  const rows: Scalar[][] = [];
+  for (let rowIndex = 0; rowIndex < pivot.rowAxis.length; rowIndex += 1) {
+    const axis = pivot.rowAxis[rowIndex];
+    const row = pivot.rows[rowIndex];
+    const out: Scalar[] = [axis.label];
+    for (const columnEntry of pivot.columnAxis) {
+      out.push(row.values[columnEntry.id]);
+    }
+    if (pivot.rowTotalName) {
+      out.push(row.total ?? null);
+    }
+    rows.push(out);
+  }
+
+  for (const footer of pivot.footerRows ?? []) {
+    const out: Scalar[] = [footer.key];
+    for (const columnEntry of pivot.columnAxis) {
+      out.push(footer.values[columnEntry.id]);
+    }
+    if (pivot.rowTotalName) {
+      out.push(footer.total ?? null);
+    }
+    rows.push(out);
+  }
+
+  return renderMarkdownTableFromMatrix(columns, rows);
+}
+
 function isMarkdownTableStart(lines: string[], startIndex: number): boolean {
   if (startIndex + 1 >= lines.length) return false;
   const header = lines[startIndex];
@@ -747,12 +789,9 @@ function isPipeDelimitedRow(line: string): boolean {
   return trimmed.startsWith("|") && trimmed.endsWith("|");
 }
 
-function injectReportTables(
-  body: string,
-  reportTables: Record<string, ReportTableEvaluation>,
-): string {
-  const hasOwnReportTable = (heading: string): heading is keyof typeof reportTables =>
-    Object.prototype.hasOwnProperty.call(reportTables, heading);
+function injectSyntheticMarkdownTables(body: string, tableLinesByHeading: Record<string, string[]>): string {
+  const hasOwnSyntheticTable = (heading: string): heading is keyof typeof tableLinesByHeading =>
+    Object.prototype.hasOwnProperty.call(tableLinesByHeading, heading);
   const lines = body.split("\n");
   const fencedLines = getFencedLines(lines);
   const headings = lines
@@ -763,12 +802,11 @@ function injectReportTables(
       heading: line.match(/^\s*#{1,6}\s+(.*)$/)?.[1].trim(),
     }))
     .filter((entry): entry is { index: number; heading: string } => Boolean(entry.heading))
-    .filter(({ heading }) => hasOwnReportTable(heading))
+    .filter(({ heading }) => hasOwnSyntheticTable(heading))
     .sort((a, b) => b.index - a.index);
 
   for (const { index, heading } of headings) {
-    const report = reportTables[heading];
-    const tableLines = renderMarkdownTable(report.columns, report.rows);
+    const tableLines = tableLinesByHeading[heading];
     let replaceStart = index + 1;
     while (replaceStart < lines.length && lines[replaceStart].trim() === "") {
       replaceStart += 1;
@@ -784,6 +822,28 @@ function injectReportTables(
   }
 
   return lines.join("\n");
+}
+
+function injectReportTables(
+  body: string,
+  reportTables: Record<string, ReportTableEvaluation>,
+): string {
+  const tableLinesByHeading = Object.create(null) as Record<string, string[]>;
+  for (const [name, report] of Object.entries(reportTables)) {
+    tableLinesByHeading[name] = renderMarkdownTable(report.columns, report.rows);
+  }
+  return injectSyntheticMarkdownTables(body, tableLinesByHeading);
+}
+
+function injectPivotTables(
+  body: string,
+  pivotTables: Record<string, PivotTableEvaluation>,
+): string {
+  const tableLinesByHeading = Object.create(null) as Record<string, string[]>;
+  for (const [name, pivot] of Object.entries(pivotTables)) {
+    tableLinesByHeading[name] = renderPivotMarkdownTable(pivot);
+  }
+  return injectSyntheticMarkdownTables(body, tableLinesByHeading);
 }
 
 function evaluateReportTables(
@@ -860,6 +920,51 @@ function parseColumnReference(sourceTable: string, reference: string): { table: 
   }
   const [table, column] = reference.split(".");
   return { table, column };
+}
+
+function buildSyntheticEvaluationPlan(
+  reportTables: Record<string, ParsedReportTable>,
+  pivotTables: Record<string, PivotTableDefinition> | undefined,
+  limits: ExpressionLimits,
+): { reportOrder: string[]; pivotOrder: string[] } {
+  const reportNames = new Set(Object.keys(reportTables));
+  const pivotNames = new Set(Object.keys(pivotTables ?? {}));
+  const nodes = Object.create(null) as Record<string, string[]>;
+
+  const syntheticNodeName = (name: string): string | undefined => {
+    if (reportNames.has(name)) return `report:${name}`;
+    if (pivotNames.has(name)) return `pivot:${name}`;
+    return undefined;
+  };
+
+  for (const [name, report] of Object.entries(reportTables)) {
+    const deps: string[] = [];
+    const dep = syntheticNodeName(report.rowsFrom);
+    if (dep) deps.push(dep);
+    nodes[`report:${name}`] = deps;
+  }
+
+  for (const [name, pivot] of Object.entries(pivotTables ?? {})) {
+    const deps = new Set<string>();
+    const rowRef = parseColumnReference(pivot.source, pivot.rows.from);
+    const columnRef = parseColumnReference(pivot.source, pivot.columns.from);
+    const candidates = [pivot.source, rowRef.table, columnRef.table];
+    for (const candidate of candidates) {
+      const dep = syntheticNodeName(candidate);
+      if (dep) deps.add(dep);
+    }
+    nodes[`pivot:${name}`] = [...deps];
+  }
+
+  const graph = buildNameDependencyGraph(nodes, limits);
+  const reportOrder = graph.order
+    .filter((node) => node.startsWith("report:"))
+    .map((node) => node.slice("report:".length));
+  const pivotOrder = graph.order
+    .filter((node) => node.startsWith("pivot:"))
+    .map((node) => node.slice("pivot:".length));
+
+  return { reportOrder, pivotOrder };
 }
 
 function uniqueByString(values: Scalar[]): Scalar[] {
@@ -1658,8 +1763,29 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
   }
 
   const parsedReportTables = parseReportTableExpressions(frontmatter.report_tables, limits);
+  let syntheticPlan: { reportOrder: string[]; pivotOrder: string[] };
+  try {
+    syntheticPlan = buildSyntheticEvaluationPlan(parsedReportTables, frontmatter.pivot_tables, limits);
+  } catch (err) {
+    throw wrapExpressionDiagnostic(err, { table: "<synthetic>", target: "<dependency>", kind: "dependency" });
+  }
+
+  const orderedParsedReportTables = Object.create(null) as Record<string, ParsedReportTable>;
+  for (const name of syntheticPlan.reportOrder) {
+    if (Object.prototype.hasOwnProperty.call(parsedReportTables, name)) {
+      orderedParsedReportTables[name] = parsedReportTables[name];
+    }
+  }
+
+  const orderedPivotTables = Object.create(null) as Record<string, PivotTableDefinition>;
+  for (const name of syntheticPlan.pivotOrder) {
+    if (Object.prototype.hasOwnProperty.call(frontmatter.pivot_tables ?? {}, name)) {
+      orderedPivotTables[name] = (frontmatter.pivot_tables ?? {})[name];
+    }
+  }
+
   const reportTableResults = evaluateReportTables(
-    parsedReportTables,
+    orderedParsedReportTables,
     rowList,
     ensureByTable,
     lookupRow,
@@ -1667,7 +1793,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     groupedAggregateResults,
     limits,
   );
-  const pivotTableResults = evaluatePivotTables(frontmatter.pivot_tables, frontmatter.tables, rowList, ensureByTable);
+  const pivotTableResults = evaluatePivotTables(orderedPivotTables, frontmatter.tables, rowList, ensureByTable);
 
   const results = Object.create(null) as Record<string, TableEvaluation>;
   for (const [name, rows] of Object.entries(rowList)) {
@@ -1704,6 +1830,7 @@ export function compileMdxtab(raw: string, options: CompileOptions = {}): Compil
     );
   }
   renderedBody = injectReportTables(renderedBody, reportTableResults);
+  renderedBody = injectPivotTables(renderedBody, pivotTableResults);
   renderedBody = interpolateAggregates(renderedBody, aggregateResults, groupedAggregateResults, bodyOffset);
   if (!includeFrontmatter && renderedBody.startsWith("\n")) {
     renderedBody = renderedBody.slice(1);

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -981,6 +981,12 @@ function uniqueByString(values: Scalar[]): Scalar[] {
 }
 
 function compareByString(a: Scalar, b: Scalar): number {
+  if (typeof a === "number" && typeof b === "number") {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+  }
+
   const left = String(a);
   const right = String(b);
   if (left < right) return -1;

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1,4 +1,5 @@
 import { buildDependencyGraph, buildNameDependencyGraph } from "./dependency-graph.js";
+import { isValidIsoDate } from "./date-utils.js";
 import { evaluateAst } from "./evaluator.js";
 import { parseExpression, type AstNode } from "./parser.js";
 import { parseFrontmatter } from "./frontmatter.js";
@@ -1055,21 +1056,6 @@ function parseIsoDatePreserveYear(isoDate: string): Date {
   date.setUTCFullYear(year, month - 1, day);
   date.setUTCHours(0, 0, 0, 0);
   return date;
-}
-
-function isValidIsoDate(value: string): boolean {
-  if (!DATE_RE.test(value)) return false;
-  const [yearText, monthText, dayText] = value.split("-");
-  const year = Number(yearText);
-  const month = Number(monthText);
-  const day = Number(dayText);
-  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
-  if (month < 1 || month > 12) return false;
-  if (day < 1) return false;
-
-  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  return day <= daysInMonth[month - 1];
 }
 
 function formatIsoDate(date: Date): string {

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -306,9 +306,20 @@ function parsePivotTables(
     );
     const normalizedColumnsFrom = validateColumnReference(name, source, columnsFrom, "columns.from");
 
-    const columnsLabel = columnsObj.label === undefined
+    const columnsLabelRaw = columnsObj.label === undefined
       ? undefined
       : expectPivotString(name, columnsObj.label, `columns.label for pivot_table ${name}`, "columns.label");
+    let columnsLabel: PivotTableDefinition["columns"]["label"];
+    if (columnsLabelRaw !== undefined) {
+      if (columnsLabelRaw !== "iso_date" && columnsLabelRaw !== "short_month_day") {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.label must be one of iso_date, short_month_day`,
+          "columns.label",
+        );
+      }
+      columnsLabel = columnsLabelRaw;
+    }
 
     let columnsRange: PivotTableDefinition["columns"]["range"];
     if (columnsObj.range !== undefined) {

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -359,12 +359,6 @@ function parsePivotTables(
     }
 
     const valueExpr = expectPivotString(name, pivotObj.value, `value for pivot_table ${name}`, "value");
-    const key = pivotObj.key === undefined
-      ? sourceTable.key ?? "id"
-      : expectPivotString(name, pivotObj.key, `key for pivot_table ${name}`, "key");
-    if (!sourceTable.columns.includes(key)) {
-      throw pivotTableError(name, `pivot_table ${name} key ${key} is not a column in source table ${source}`, "key");
-    }
 
     if (
       pivotObj.empty_cells !== undefined
@@ -423,7 +417,6 @@ function parsePivotTables(
 
     result[name] = {
       source,
-      key,
       rows: {
         from: rowsFrom,
         order: rowsOrder,

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml } from "yaml";
 import { DiagnosticError, lineRange } from "./diagnostics.js";
+import { isValidIsoDate } from "./date-utils.js";
 import type {
   FrontmatterDocument,
   PivotTableDefinition,
@@ -7,8 +8,6 @@ import type {
   SummaryRowDefinition,
   TableFrontmatter,
 } from "./types.js";
-
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function expectObject(value: unknown, context: string): Record<string, unknown> {
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -156,22 +155,6 @@ function parseReportTables(
   }
 
   return result;
-}
-
-function isValidIsoDate(value: string): boolean {
-  if (!ISO_DATE_RE.test(value)) return false;
-  const [yearRaw, monthRaw, dayRaw] = value.split("-");
-  const year = Number(yearRaw);
-  const month = Number(monthRaw);
-  const day = Number(dayRaw);
-  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
-
-  if (month < 1 || month > 12) return false;
-  if (day < 1) return false;
-
-  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
-  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  return day <= daysInMonth[month - 1];
 }
 
 function parsePivotTables(

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -228,6 +228,7 @@ function parsePivotTables(
 
     let tableName = sourceTableName;
     let columnName = ref;
+    let usedTableReference = false;
     if (ref.includes(".")) {
       const parts = ref.split(".");
       if (parts.length !== 2 || parts[0].trim().length === 0 || parts[1].trim().length === 0) {
@@ -239,6 +240,7 @@ function parsePivotTables(
       }
       tableName = parts[0].trim();
       columnName = parts[1].trim();
+      usedTableReference = true;
     }
 
     if (!hasOwnTable(tableName)) {
@@ -252,6 +254,14 @@ function parsePivotTables(
       throw pivotTableError(
         pivotName,
         `pivot_table ${pivotName} ${columnLabel} references unknown column ${columnName} in table ${tableName}`,
+        columnLabel,
+      );
+    }
+
+    if (usedTableReference && !tables[sourceTableName].columns.includes(columnName)) {
+      throw pivotTableError(
+        pivotName,
+        `pivot_table ${pivotName} ${columnLabel} references column ${columnName} that does not exist in source table ${sourceTableName}`,
         columnLabel,
       );
     }

--- a/packages/core/src/frontmatter.ts
+++ b/packages/core/src/frontmatter.ts
@@ -1,6 +1,14 @@
 import { parse as parseYaml } from "yaml";
 import { DiagnosticError, lineRange } from "./diagnostics.js";
-import type { FrontmatterDocument, ReportTableDefinition, SummaryRowDefinition, TableFrontmatter } from "./types.js";
+import type {
+  FrontmatterDocument,
+  PivotTableDefinition,
+  ReportTableDefinition,
+  SummaryRowDefinition,
+  TableFrontmatter,
+} from "./types.js";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function expectObject(value: unknown, context: string): Record<string, unknown> {
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
@@ -150,6 +158,290 @@ function parseReportTables(
   return result;
 }
 
+function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_RE.test(value)) return false;
+  const [yearRaw, monthRaw, dayRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false;
+
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+  const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
+function parsePivotTables(
+  value: unknown,
+  tables: Record<string, TableFrontmatter>,
+  reportTables: Record<string, ReportTableDefinition>,
+): Record<string, PivotTableDefinition> {
+  const obj = expectObject(value, "pivot_tables");
+  const result = Object.create(null) as Record<string, PivotTableDefinition>;
+  const hasOwnTable = (name: string): name is keyof typeof tables =>
+    Object.prototype.hasOwnProperty.call(tables, name);
+  const hasOwnReportTable = (name: string): boolean =>
+    Object.prototype.hasOwnProperty.call(reportTables, name);
+  const pivotTableError = (name: string, message: string, column?: string): DiagnosticError =>
+    new DiagnosticError({ code: "E_FRONTMATTER", message, table: name, column, range: lineRange(0) });
+
+  const expectPivotObject = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectObject(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const expectPivotString = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectString(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const expectPivotStringArray = (pivotName: string, pivotValue: unknown, context: string, column?: string) => {
+    try {
+      return expectStringArray(pivotValue, context);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw pivotTableError(pivotName, message, column);
+    }
+  };
+
+  const validateColumnReference = (
+    pivotName: string,
+    sourceTableName: string,
+    reference: string,
+    columnLabel: "rows.from" | "columns.from",
+  ): string => {
+    const ref = reference.trim();
+    if (ref.length === 0) {
+      throw pivotTableError(pivotName, `pivot_table ${pivotName} ${columnLabel} must not be empty`, columnLabel);
+    }
+
+    let tableName = sourceTableName;
+    let columnName = ref;
+    if (ref.includes(".")) {
+      const parts = ref.split(".");
+      if (parts.length !== 2 || parts[0].trim().length === 0 || parts[1].trim().length === 0) {
+        throw pivotTableError(
+          pivotName,
+          `pivot_table ${pivotName} ${columnLabel} must be a column name or table.column reference`,
+          columnLabel,
+        );
+      }
+      tableName = parts[0].trim();
+      columnName = parts[1].trim();
+    }
+
+    if (!hasOwnTable(tableName)) {
+      throw pivotTableError(
+        pivotName,
+        `pivot_table ${pivotName} ${columnLabel} references unknown table ${tableName}`,
+        columnLabel,
+      );
+    }
+    if (!tables[tableName].columns.includes(columnName)) {
+      throw pivotTableError(
+        pivotName,
+        `pivot_table ${pivotName} ${columnLabel} references unknown column ${columnName} in table ${tableName}`,
+        columnLabel,
+      );
+    }
+
+    return tableName === sourceTableName ? columnName : `${tableName}.${columnName}`;
+  };
+
+  for (const [name, pivotValue] of Object.entries(obj)) {
+    if (hasOwnTable(name)) {
+      throw pivotTableError(name, `pivot_tables.${name} conflicts with table ${name}`);
+    }
+    if (hasOwnReportTable(name)) {
+      throw pivotTableError(name, `pivot_tables.${name} conflicts with report_table ${name}`);
+    }
+
+    const pivotObj = expectPivotObject(name, pivotValue, `pivot_table ${name}`);
+    const source = expectPivotString(name, pivotObj.source, `source for pivot_table ${name}`, "source");
+    if (!hasOwnTable(source)) {
+      throw pivotTableError(name, `pivot_table ${name} references unknown source table ${source}`, "source");
+    }
+    const sourceTable = tables[source];
+
+    if (pivotObj.rows === undefined) {
+      throw pivotTableError(name, `pivot_table ${name}: rows is required`, "rows");
+    }
+    const rowsObj = expectPivotObject(name, pivotObj.rows, `rows for pivot_table ${name}`, "rows");
+    const rowsFromRaw = expectPivotString(name, rowsObj.from, `rows.from for pivot_table ${name}`, "rows.from");
+    const rowsFrom = validateColumnReference(name, source, rowsFromRaw, "rows.from");
+    const rowsOrder = rowsObj.order === undefined
+      ? undefined
+      : expectPivotStringArray(name, rowsObj.order, `rows.order for pivot_table ${name}`, "rows.order");
+
+    if (pivotObj.columns === undefined) {
+      throw pivotTableError(name, `pivot_table ${name}: columns is required`, "columns");
+    }
+    const columnsObj = expectPivotObject(name, pivotObj.columns, `columns for pivot_table ${name}`, "columns");
+    const columnsFrom = expectPivotString(
+      name,
+      columnsObj.from,
+      `columns.from for pivot_table ${name}`,
+      "columns.from",
+    );
+    const normalizedColumnsFrom = validateColumnReference(name, source, columnsFrom, "columns.from");
+
+    const columnsLabel = columnsObj.label === undefined
+      ? undefined
+      : expectPivotString(name, columnsObj.label, `columns.label for pivot_table ${name}`, "columns.label");
+
+    let columnsRange: PivotTableDefinition["columns"]["range"];
+    if (columnsObj.range !== undefined) {
+      const rangeObj = expectPivotObject(name, columnsObj.range, `columns.range for pivot_table ${name}`, "columns.range");
+      const start = expectPivotString(
+        name,
+        rangeObj.start,
+        `columns.range.start for pivot_table ${name}`,
+        "columns.range.start",
+      );
+      const end = expectPivotString(
+        name,
+        rangeObj.end,
+        `columns.range.end for pivot_table ${name}`,
+        "columns.range.end",
+      );
+
+      if (!isValidIsoDate(start)) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.start must be an ISO date (YYYY-MM-DD)`,
+          "columns.range.start",
+        );
+      }
+      if (!isValidIsoDate(end)) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.end must be an ISO date (YYYY-MM-DD)`,
+          "columns.range.end",
+        );
+      }
+      if (start > end) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.start must be before or equal to columns.range.end`,
+          "columns.range",
+        );
+      }
+
+      if (
+        rangeObj.step !== undefined
+        && rangeObj.step !== "day"
+        && rangeObj.step !== "week"
+        && rangeObj.step !== "month"
+      ) {
+        throw pivotTableError(
+          name,
+          `pivot_table ${name} columns.range.step must be one of day, week, month`,
+          "columns.range.step",
+        );
+      }
+
+      columnsRange = {
+        start,
+        end,
+        step: rangeObj.step,
+      };
+    }
+
+    const valueExpr = expectPivotString(name, pivotObj.value, `value for pivot_table ${name}`, "value");
+    const key = pivotObj.key === undefined
+      ? sourceTable.key ?? "id"
+      : expectPivotString(name, pivotObj.key, `key for pivot_table ${name}`, "key");
+    if (!sourceTable.columns.includes(key)) {
+      throw pivotTableError(name, `pivot_table ${name} key ${key} is not a column in source table ${source}`, "key");
+    }
+
+    if (
+      pivotObj.empty_cells !== undefined
+      && pivotObj.empty_cells !== "null"
+      && pivotObj.empty_cells !== "zero"
+      && pivotObj.empty_cells !== "empty-string"
+      && pivotObj.empty_cells !== "error"
+    ) {
+      throw pivotTableError(
+        name,
+        `Invalid empty_cells value for pivot_table ${name}: ${String(pivotObj.empty_cells)}`,
+        "empty_cells",
+      );
+    }
+
+    let totals: PivotTableDefinition["totals"];
+    if (pivotObj.totals !== undefined) {
+      const totalsObj = expectPivotObject(name, pivotObj.totals, `totals for pivot_table ${name}`, "totals");
+      const totalsRow = totalsObj.row === undefined
+        ? undefined
+        : expectPivotString(name, totalsObj.row, `totals.row for pivot_table ${name}`, "totals.row");
+
+      let totalsColumn: NonNullable<NonNullable<PivotTableDefinition["totals"]>["column"]> | undefined;
+      if (totalsObj.column !== undefined) {
+        const columnObj = expectPivotObject(name, totalsObj.column, `totals.column for pivot_table ${name}`, "totals.column");
+        const parsedTotalsColumn = Object.create(null) as NonNullable<NonNullable<PivotTableDefinition["totals"]>["column"]>;
+        for (const [footerName, footerValue] of Object.entries(columnObj)) {
+          const footerPath = `totals.column.${footerName}`;
+          const footerObj = expectPivotObject(
+            name,
+            footerValue,
+            `${footerPath} for pivot_table ${name}`,
+            footerPath,
+          );
+          if (
+            footerObj.mode !== undefined
+            && footerObj.mode !== "sum"
+            && footerObj.mode !== "running_sum"
+          ) {
+            throw pivotTableError(
+              name,
+              `pivot_table ${name} totals.column.${footerName}.mode must be one of sum, running_sum`,
+              `${footerPath}.mode`,
+            );
+          }
+          parsedTotalsColumn[footerName] = { mode: footerObj.mode as "sum" | "running_sum" | undefined };
+        }
+        totalsColumn = parsedTotalsColumn;
+      }
+
+      totals = {
+        row: totalsRow,
+        column: totalsColumn,
+      };
+    }
+
+    result[name] = {
+      source,
+      key,
+      rows: {
+        from: rowsFrom,
+        order: rowsOrder,
+      },
+      columns: {
+        from: normalizedColumnsFrom,
+        range: columnsRange,
+        label: columnsLabel,
+      },
+      value: valueExpr,
+      empty_cells: pivotObj.empty_cells,
+      totals,
+    };
+  }
+
+  return result;
+}
+
 function validateTable(name: string, value: unknown): TableFrontmatter {
   const obj = expectObject(value, `table ${name}`);
   const columns = expectStringArray(obj.columns, `columns for table ${name}`);
@@ -236,8 +528,11 @@ export function parseFrontmatter(raw: string): FrontmatterDocument {
     const report_tables = obj.report_tables
       ? parseReportTables(obj.report_tables, tables)
       : undefined;
+    const pivot_tables = obj.pivot_tables
+      ? parsePivotTables(obj.pivot_tables, tables, report_tables ?? Object.create(null))
+      : undefined;
 
-    return { mdxtab, tables, report_tables };
+    return { mdxtab, tables, report_tables, pivot_tables };
   } catch (err) {
     if (err instanceof DiagnosticError) throw err;
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,7 +41,7 @@ export interface PivotColumnsRangeDefinition {
 export interface PivotColumnsDefinition {
   from: string;
   range?: PivotColumnsRangeDefinition;
-  label?: string;
+  label?: "iso_date" | "short_month_day";
 }
 
 export interface PivotTotalsColumnModeDefinition {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,42 @@ export interface ReportTableDefinition {
   cells: Record<string, string>;
 }
 
+export interface PivotRowsDefinition {
+  from: string;
+  order?: string[];
+}
+
+export interface PivotColumnsRangeDefinition {
+  start: string;
+  end: string;
+  step?: "day" | "week" | "month";
+}
+
+export interface PivotColumnsDefinition {
+  from: string;
+  range?: PivotColumnsRangeDefinition;
+  label?: string;
+}
+
+export interface PivotTotalsColumnModeDefinition {
+  mode?: "sum" | "running_sum";
+}
+
+export interface PivotTotalsDefinition {
+  row?: string;
+  column?: Record<string, PivotTotalsColumnModeDefinition>;
+}
+
+export interface PivotTableDefinition {
+  source: string;
+  rows: PivotRowsDefinition;
+  columns: PivotColumnsDefinition;
+  value: string;
+  key?: string;
+  empty_cells?: "null" | "zero" | "empty-string" | "error";
+  totals?: PivotTotalsDefinition;
+}
+
 export interface TableFrontmatter {
   key?: string;
   columns: string[];
@@ -41,6 +77,7 @@ export interface FrontmatterDocument {
   mdxtab: string;
   tables: Record<string, TableFrontmatter>;
   report_tables?: Record<string, ReportTableDefinition>;
+  pivot_tables?: Record<string, PivotTableDefinition>;
 }
 
 export interface HeaderCell {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -131,10 +131,44 @@ export interface ReportTableEvaluation {
   rows: Record<string, Scalar>[];
 }
 
+export interface PivotAxisEntry {
+  id: string;
+  key: Scalar;
+  label: string;
+  index: number;
+}
+
+export interface PivotRowEvaluation {
+  key: Scalar;
+  values: Record<string, Scalar>;
+  total?: Scalar;
+}
+
+export interface PivotFooterRowEvaluation {
+  key: string;
+  mode: "sum" | "running_sum";
+  values: Record<string, Scalar>;
+  total?: Scalar;
+}
+
+export interface PivotTableEvaluation {
+  name: string;
+  source: string;
+  rowsFrom: string;
+  columnsFrom: string;
+  value: string;
+  rowAxis: PivotAxisEntry[];
+  columnAxis: PivotAxisEntry[];
+  rows: PivotRowEvaluation[];
+  rowTotalName?: string;
+  footerRows?: PivotFooterRowEvaluation[];
+}
+
 export interface CompileResult {
   frontmatter: FrontmatterDocument;
   tables: Record<string, TableEvaluation>;
   reportTables: Record<string, ReportTableEvaluation>;
+  pivotTables: Record<string, PivotTableEvaluation>;
   rendered: string;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,7 +58,6 @@ export interface PivotTableDefinition {
   rows: PivotRowsDefinition;
   columns: PivotColumnsDefinition;
   value: string;
-  key?: string;
   empty_cells?: "null" | "zero" | "empty-string" | "error";
   totals?: PivotTotalsDefinition;
 }

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -4,12 +4,14 @@
 
 - Command: **MDXTab: Render Preview** (`mdxtab.renderPreview`) — renders the active Markdown file through the MDXTab compiler into a preview document.
 - Command: **MDXTab: Validate Document** (`mdxtab.validateDocument`) — validates the active Markdown file and reports diagnostic count/status.
-- Command: **MDXTab: Show Table Schema** (`mdxtab.showTableSchema`) — opens a markdown view with the parsed `tables` frontmatter schema as JSON.
+- Command: **MDXTab: Show Table Schema** (`mdxtab.showTableSchema`) — opens a markdown view with parsed `tables`, `report_tables`, and `pivot_tables` frontmatter schema as JSON.
 - Diagnostics: recompiles on open/change/save; errors surface as markdown diagnostics at the top of the file.
 - Preview scheme: `mdxtab-preview:` opens a virtual document with the rendered output (frontmatter + interpolated aggregates).
 - **Computed column preview**: columns defined in frontmatter `computed` are rendered in the Markdown preview with their evaluated per-row values. Columns already authored as headers have their empty cells filled in; columns not in the source table are appended automatically.
 - **Summary row preview**: rows defined in frontmatter `summary_rows` are rendered as synthetic rows appended at the bottom of the table preview.
 - **Synthetic report table preview**: frontmatter `report_tables` render as derived Markdown tables at matching headings such as `## category_balances`.
+- **Synthetic pivot table preview**: frontmatter `pivot_tables` render as derived matrix tables at matching headings such as `## liquidity`.
+- **Heading completion + hover for synthetic tables**: completion suggests `report_tables` and `pivot_tables` names when editing Markdown headings, and hover shows quick details on matching synthetic-table headings.
 - **Expression guardrails**: validation rejects pathological computed/aggregate
   expressions with `E_LIMIT` diagnostics before they can trigger stack overflow
   or excessive work.

--- a/packages/vscode/snippets/mdxtab.markdown.json
+++ b/packages/vscode/snippets/mdxtab.markdown.json
@@ -26,5 +26,37 @@
       "| ${4} | ${5} |"
     ],
     "description": "Insert a basic MDXTab table scaffold."
+  },
+  "MDXTab pivot frontmatter block": {
+    "prefix": "mdxtab-pivot",
+    "body": [
+      "pivot_tables:",
+      "  ${1:pivot_name}:",
+      "    source: ${2:entries}",
+      "    rows:",
+      "      from: ${3:category}",
+      "    columns:",
+      "      from: ${4:date}",
+      "      range:",
+      "        start: ${5:2026-04-24}",
+      "        end: ${6:2026-04-26}",
+      "        step: ${7:day}",
+      "      label: ${8:short_month_day}",
+      "    value: sum(${9:amount})",
+      "    empty_cells: ${10:zero}",
+      "    totals:",
+      "      row: ${11:total}",
+      "      column:",
+      "        ${12:accumulated}:",
+      "          mode: ${13:running_sum}"
+    ],
+    "description": "Insert a pivot_tables frontmatter scaffold."
+  },
+  "MDXTab pivot render heading": {
+    "prefix": "mdxtab-pivot-heading",
+    "body": [
+      "## ${1:pivot_name}"
+    ],
+    "description": "Insert a Markdown heading render target for a pivot table."
   }
 }

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -569,6 +569,48 @@ describe("vscode extension smoke", () => {
     expect(labels).toContain("liquidity");
   });
 
+  it("does not provide heading completions one character past heading text", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+      report_tables: {
+        "category-balances": {
+          rows_from: "entries",
+          columns: ["label"],
+          cells: {
+            label: "row.id",
+          },
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "entries",
+          rows: { from: "id" },
+          columns: { from: "id" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/completion-heading-end.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, amount]\n---\n\n## liquidity\n",
+    );
+
+    const items = state.completionProvider?.provideCompletionItems(sourceDoc, new vscode.Position(7, 12)) ?? [];
+
+    expect(items).toEqual([]);
+  });
+
   it("provides hover details for synthetic table headings", async () => {
     const vscode = await import("vscode");
     const extension = await import("../extension.js");

--- a/packages/vscode/src/__tests__/extension.smoke.spec.ts
+++ b/packages/vscode/src/__tests__/extension.smoke.spec.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = {
   commands: new Map<string, (...args: unknown[]) => unknown>(),
   previewProvider: undefined as undefined | { provideTextDocumentContent: (uri: unknown) => Promise<string> },
+  hoverProvider: undefined as undefined | { provideHover: (document: MockDocument, position: MockPosition) => unknown },
+  completionProvider: undefined as undefined | {
+    provideCompletionItems: (document: MockDocument, position: MockPosition) => Array<{ label: string }>;
+  },
   openHandlers: [] as Array<(doc: MockDocument) => void>,
   closeHandlers: [] as Array<(doc: MockDocument) => void>,
   changeHandlers: [] as Array<(event: { document: MockDocument }) => void>,
@@ -225,8 +229,19 @@ vi.mock("vscode", () => {
   const languages = {
     createDiagnosticCollection: vi.fn(() => diagnosticCollection),
     registerDocumentSymbolProvider: vi.fn(() => ({ dispose: () => undefined })),
-    registerHoverProvider: vi.fn(() => ({ dispose: () => undefined })),
-    registerCompletionItemProvider: vi.fn(() => ({ dispose: () => undefined })),
+    registerHoverProvider: vi.fn((_selector: unknown, provider: { provideHover: (document: MockDocument, position: MockPosition) => unknown }) => {
+      state.hoverProvider = provider;
+      return { dispose: () => undefined };
+    }),
+    registerCompletionItemProvider: vi.fn(
+      (
+        _selector: unknown,
+        provider: { provideCompletionItems: (document: MockDocument, position: MockPosition) => Array<{ label: string }> },
+      ) => {
+        state.completionProvider = provider;
+        return { dispose: () => undefined };
+      },
+    ),
     registerDefinitionProvider: vi.fn(() => ({ dispose: () => undefined })),
     registerCodeActionsProvider: vi.fn(() => ({ dispose: () => undefined })),
   };
@@ -288,6 +303,8 @@ describe("vscode extension smoke", () => {
   beforeEach(() => {
     state.commands.clear();
     state.previewProvider = undefined;
+    state.hoverProvider = undefined;
+    state.completionProvider = undefined;
     state.openHandlers.length = 0;
     state.closeHandlers.length = 0;
     state.changeHandlers.length = 0;
@@ -419,7 +436,25 @@ describe("vscode extension smoke", () => {
           columns: ["id", "amount"],
         },
       },
-    });
+      report_tables: {
+        category_balances: {
+          rows_from: "expenses",
+          columns: ["label", "total"],
+          cells: {
+            label: "row.id",
+            total: "expenses.sum_total",
+          },
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "expenses",
+          rows: { from: "id" },
+          columns: { from: "amount" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
 
     const sourceUri = MockUri.from({ scheme: "file", path: "/tmp/schema.md" });
     const sourceDoc = createDoc(
@@ -437,6 +472,8 @@ describe("vscode extension smoke", () => {
     expect(state.virtualDocumentContents.length).toBe(1);
     expect(state.virtualDocumentContents[0]).toContain("# MDXTab Table Schema");
     expect(state.virtualDocumentContents[0]).toContain('"expenses"');
+    expect(state.virtualDocumentContents[0]).toContain('"report_tables"');
+    expect(state.virtualDocumentContents[0]).toContain('"pivot_tables"');
   });
 
   it("warns when show-table-schema runs on a non-MDXTab file", async () => {
@@ -486,5 +523,120 @@ describe("vscode extension smoke", () => {
       "MDXTab: could not read table schema from frontmatter: invalid YAML near line 2",
     );
     expect(state.shownDocumentCount).toBe(0);
+  });
+
+  it("provides completion items for synthetic table names in headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+      report_tables: {
+        "category-balances": {
+          rows_from: "entries",
+          columns: ["label"],
+          cells: {
+            label: "row.id",
+          },
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "entries",
+          rows: { from: "id" },
+          columns: { from: "id" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/completion-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, amount]\n---\n\n## \n",
+    );
+
+    const items = state.completionProvider?.provideCompletionItems(sourceDoc, new vscode.Position(7, 3)) ?? [];
+    const labels = items.map((item) => item.label);
+
+    expect(labels).toContain("category-balances");
+    expect(labels).toContain("liquidity");
+  });
+
+  it("provides hover details for synthetic table headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "amount"],
+        },
+      },
+      report_tables: {
+        "category-balances": {
+          rows_from: "entries",
+          columns: ["label", "total"],
+          cells: {
+            label: "row.id",
+            total: "entries.total",
+          },
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/hover-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, amount]\n---\n\n## category-balances\n",
+    );
+
+    const hover = state.hoverProvider?.provideHover(sourceDoc, new vscode.Position(7, 6)) as { contents: { value: string } } | undefined;
+    expect(hover?.contents.value).toContain("Report Table");
+    expect(hover?.contents.value).toContain("category-balances.rows_from");
+    expect(hover?.contents.value).toContain("rows_from=entries");
+  });
+
+  it("provides hover details for pivot table headings", async () => {
+    const vscode = await import("vscode");
+    const extension = await import("../extension.js");
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> };
+    extension.activate(context as never);
+
+    parseFrontmatter.mockReturnValue({
+      tables: {
+        entries: {
+          key: "id",
+          columns: ["id", "date", "category", "amount"],
+        },
+      },
+      pivot_tables: {
+        liquidity: {
+          source: "entries",
+          rows: { from: "category" },
+          columns: { from: "date" },
+          value: "sum(amount)",
+        },
+      },
+    } as any);
+
+    const sourceDoc = createDoc(
+      MockUri.from({ scheme: "file", path: "/tmp/hover-pivot-heading.md" }),
+      "---\nmdxtab: \"1.0\"\ntables:\n  entries:\n    columns: [id, date, category, amount]\n---\n\n## liquidity\n",
+    );
+
+    const hover = state.hoverProvider?.provideHover(sourceDoc, new vscode.Position(7, 6)) as { contents: { value: string } } | undefined;
+    expect(hover?.contents.value).toContain("Pivot Table");
+    expect(hover?.contents.value).toContain("liquidity.source");
+    expect(hover?.contents.value).toContain("source=entries");
+    expect(hover?.contents.value).toContain("rows.from=category");
   });
 });

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -524,8 +524,8 @@ function findBodyHoverEntry(
   const lineText = lines[position.line] ?? "";
   const heading = extractHeadingInfo(lineText);
   if (heading) {
-    const { text, start, end } = heading;
-    if (position.character >= start && position.character <= end) {
+    const { text, start, endExclusive } = heading;
+    if (position.character >= start && position.character < endExclusive) {
       const report = frontmatter.report_tables?.[text];
       if (report) {
         return {
@@ -535,9 +535,9 @@ function findBodyHoverEntry(
           expr: `rows_from=${report.rows_from}, columns=${report.columns.join(", ")}`,
           line: position.line,
           start,
-          end,
+          end: endExclusive,
           exprStart: start,
-          exprEnd: end,
+          exprEnd: endExclusive,
         };
       }
       const pivot = frontmatter.pivot_tables?.[text];
@@ -549,9 +549,9 @@ function findBodyHoverEntry(
           expr: `source=${pivot.source}, rows.from=${pivot.rows.from}, columns.from=${pivot.columns.from}, value=${pivot.value}`,
           line: position.line,
           start,
-          end,
+          end: endExclusive,
           exprStart: start,
-          exprEnd: end,
+          exprEnd: endExclusive,
         };
       }
     }
@@ -630,20 +630,23 @@ function matchInterpolationStart(line: string, position: number): { start: numbe
 function matchHeadingStart(line: string, position: number): { start: number } | undefined {
   const heading = extractHeadingInfo(line);
   if (!heading) return undefined;
-  const { start, end } = heading;
-  if (position < start || position > end) return undefined;
+  const { start, endExclusive } = heading;
+  if (start === endExclusive) {
+    return position === start ? { start } : undefined;
+  }
+  if (position < start || position >= endExclusive) return undefined;
   return { start };
 }
 
-function extractHeadingInfo(line: string): { text: string; start: number; end: number } | undefined {
+function extractHeadingInfo(line: string): { text: string; start: number; endExclusive: number } | undefined {
   const markerMatch = line.match(/^\s*#{1,6}\s+/);
   if (!markerMatch) return undefined;
   const rawHeading = line.slice(markerMatch[0].length);
   const text = rawHeading.trim();
   const leadingWhitespace = rawHeading.match(/^\s*/)?.[0].length ?? 0;
   const start = markerMatch[0].length + leadingWhitespace;
-  const end = start + text.length;
-  return { text, start, end };
+  const endExclusive = start + text.length;
+  return { text, start, endExclusive };
 }
 
 function findDotCompletionTable(

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -168,7 +168,7 @@ class MdxtabSymbolProvider implements DocumentSymbolProvider {
 
 type HoverEntry = {
   table: string;
-  kind: "computed" | "aggregate";
+  kind: "computed" | "aggregate" | "report-table" | "pivot-table";
   name: string;
   expr: string;
   line: number;
@@ -186,7 +186,14 @@ class MdxtabHoverProvider implements HoverProvider {
     const entry = findHoverEntry(document, position, this.cache);
     if (!entry) return undefined;
 
-    const title = entry.kind === "computed" ? "Computed" : "Aggregate";
+    const title =
+      entry.kind === "computed"
+        ? "Computed"
+        : entry.kind === "aggregate"
+        ? "Aggregate"
+        : entry.kind === "report-table"
+        ? "Report Table"
+        : "Pivot Table";
     const label = `${entry.table}.${entry.name}`;
     const md = new MarkdownString(`**${title}:** ${label}\n\n\`${entry.expr}\``);
     return new Hover(md);
@@ -200,7 +207,7 @@ class MdxtabCompletionProvider {
     if (document.languageId !== "markdown") return [];
     const context = getParsedContext(document, this.cache);
     if (!context.frontmatter || !context.frontmatterBounds) return [];
-    const { frontmatter: parsedFrontmatter, tables: parsedTables, entries, lines } = context;
+    const { frontmatter: parsedFrontmatter, tables: parsedTables, entries, lines, fencedLines } = context;
     const entry = entries.find(
       (item) =>
         item.line === position.line && position.character >= item.exprStart && position.character <= item.exprEnd,
@@ -237,6 +244,19 @@ class MdxtabCompletionProvider {
     }
 
     if (parsedFrontmatter && parsedTables) {
+      const headingStart = fencedLines.has(position.line)
+        ? undefined
+        : matchHeadingStart(lines[position.line] ?? "", position.character);
+      if (headingStart) {
+        for (const name of Object.keys(parsedFrontmatter.report_tables ?? {})) {
+          items.push(new CompletionItem(name, CompletionItemKind.Struct));
+        }
+        for (const name of Object.keys(parsedFrontmatter.pivot_tables ?? {})) {
+          items.push(new CompletionItem(name, CompletionItemKind.Struct));
+        }
+        return items;
+      }
+
       const interpolation = matchAggregateInterpolation(lines[position.line] ?? "", position.character);
       if (interpolation) {
         const table = parsedFrontmatter.tables[interpolation.table];
@@ -371,7 +391,7 @@ function findHoverEntry(
   cache: Map<string, ParsedContext>,
 ): HoverEntry | undefined {
   const context = getParsedContext(document, cache);
-  const { lines, frontmatterBounds, frontmatter, tables, entries } = context;
+  const { lines, frontmatterBounds, frontmatter, tables, entries, fencedLines } = context;
   if (!frontmatterBounds) return undefined;
 
   if (position.line > frontmatterBounds.start && position.line < frontmatterBounds.end) {
@@ -383,7 +403,7 @@ function findHoverEntry(
   }
 
   if (frontmatter && tables) {
-    return findBodyHoverEntry(lines, position, frontmatter, tables);
+    return findBodyHoverEntry(lines, position, frontmatter, tables, fencedLines);
   }
 
   return undefined;
@@ -395,6 +415,33 @@ function getFrontmatterBounds(lines: string[]): { start: number; end: number } |
     if (lines[i].trim() === "---") return { start: 0, end: i };
   }
   return undefined;
+}
+
+function getFencedLines(lines: string[]): Set<number> {
+  const fencedLines = new Set<number>();
+  let inFence = false;
+  let fenceTicks = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (inFence) {
+      fencedLines.add(i);
+      const closeRe = new RegExp(`^\\s*` + "`".repeat(fenceTicks) + `\\s*$`);
+      if (closeRe.test(lines[i])) {
+        inFence = false;
+        fenceTicks = 0;
+      }
+      continue;
+    }
+
+    const openMatch = lines[i].match(/^\s*(`{3,})/);
+    if (openMatch) {
+      inFence = true;
+      fenceTicks = openMatch[1].length;
+      fencedLines.add(i);
+    }
+  }
+
+  return fencedLines;
 }
 
 function parseFrontmatterEntries(lines: string[], start: number, end: number): HoverEntry[] {
@@ -471,8 +518,45 @@ function findBodyHoverEntry(
   position: Position,
   frontmatter: ReturnType<typeof parseFrontmatter>,
   tables: ReturnType<typeof parseMarkdownTables>,
+  fencedLines: Set<number>,
 ): HoverEntry | undefined {
+  if (fencedLines.has(position.line)) return undefined;
   const lineText = lines[position.line] ?? "";
+  const heading = extractHeadingInfo(lineText);
+  if (heading) {
+    const { text, start, end } = heading;
+    if (position.character >= start && position.character <= end) {
+      const report = frontmatter.report_tables?.[text];
+      if (report) {
+        return {
+          table: text,
+          kind: "report-table",
+          name: "rows_from",
+          expr: `rows_from=${report.rows_from}, columns=${report.columns.join(", ")}`,
+          line: position.line,
+          start,
+          end,
+          exprStart: start,
+          exprEnd: end,
+        };
+      }
+      const pivot = frontmatter.pivot_tables?.[text];
+      if (pivot) {
+        return {
+          table: text,
+          kind: "pivot-table",
+          name: "source",
+          expr: `source=${pivot.source}, rows.from=${pivot.rows.from}, columns.from=${pivot.columns.from}, value=${pivot.value}`,
+          line: position.line,
+          start,
+          end,
+          exprStart: start,
+          exprEnd: end,
+        };
+      }
+    }
+  }
+
   const aggregateMatch = matchAggregateInterpolation(lineText, position.character);
   if (aggregateMatch) {
     const table = frontmatter.tables[aggregateMatch.table];
@@ -541,6 +625,25 @@ function matchInterpolationStart(line: string, position: number): { start: numbe
   const endIndex = line.indexOf("}}", startIndex + 2);
   if (endIndex !== -1 && endIndex < position) return undefined;
   return { start: startIndex };
+}
+
+function matchHeadingStart(line: string, position: number): { start: number } | undefined {
+  const heading = extractHeadingInfo(line);
+  if (!heading) return undefined;
+  const { start, end } = heading;
+  if (position < start || position > end) return undefined;
+  return { start };
+}
+
+function extractHeadingInfo(line: string): { text: string; start: number; end: number } | undefined {
+  const markerMatch = line.match(/^\s*#{1,6}\s+/);
+  if (!markerMatch) return undefined;
+  const rawHeading = line.slice(markerMatch[0].length);
+  const text = rawHeading.trim();
+  const leadingWhitespace = rawHeading.match(/^\s*/)?.[0].length ?? 0;
+  const start = markerMatch[0].length + leadingWhitespace;
+  const end = start + text.length;
+  return { text, start, end };
 }
 
 function findDotCompletionTable(
@@ -961,6 +1064,7 @@ function extractContextValue(message: string, key: string): string | undefined {
 type ParsedContext = {
   version: number;
   lines: string[];
+  fencedLines: Set<number>;
   frontmatterBounds?: { start: number; end: number };
   frontmatter?: ReturnType<typeof parseFrontmatter>;
   tables?: ReturnType<typeof parseMarkdownTables>;
@@ -974,6 +1078,7 @@ function getParsedContext(document: TextDocument, cache: Map<string, ParsedConte
 
   const text = document.getText();
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const fencedLines = getFencedLines(lines);
   const frontmatterBounds = getFrontmatterBounds(lines);
   let frontmatter: ReturnType<typeof parseFrontmatter> | undefined;
   let tables: ReturnType<typeof parseMarkdownTables> | undefined;
@@ -994,6 +1099,7 @@ function getParsedContext(document: TextDocument, cache: Map<string, ParsedConte
   const parsed: ParsedContext = {
     version: document.version,
     lines,
+    fencedLines,
     frontmatterBounds,
     frontmatter,
     tables,
@@ -1162,13 +1268,23 @@ export function activate(context: ExtensionContext) {
     }
 
     const tableCount = Object.keys(frontmatter.tables).length;
-    if (tableCount === 0) {
-      window.showInformationMessage("MDXTab: no table schemas found in frontmatter");
+    const reportCount = Object.keys(frontmatter.report_tables ?? {}).length;
+    const pivotCount = Object.keys(frontmatter.pivot_tables ?? {}).length;
+    if (tableCount === 0 && reportCount === 0 && pivotCount === 0) {
+      window.showInformationMessage("MDXTab: no schemas found in frontmatter");
       return;
     }
 
     try {
-      const schemaJson = JSON.stringify({ tables: frontmatter.tables }, null, 2);
+      const schemaJson = JSON.stringify(
+        {
+          tables: frontmatter.tables,
+          report_tables: frontmatter.report_tables ?? {},
+          pivot_tables: frontmatter.pivot_tables ?? {},
+        },
+        null,
+        2,
+      );
       const schemaDoc = await workspace.openTextDocument({
         language: "markdown",
         content: [

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -425,7 +425,7 @@ function getFencedLines(lines: string[]): Set<number> {
   for (let i = 0; i < lines.length; i += 1) {
     if (inFence) {
       fencedLines.add(i);
-      const closeRe = new RegExp(`^\\s*` + "`".repeat(fenceTicks) + `\\s*$`);
+      const closeRe = new RegExp(`^\\s*` + "`" + `{${fenceTicks},}\\s*$`);
       if (closeRe.test(lines[i])) {
         inFence = false;
         fenceTicks = 0;

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -32,6 +32,27 @@ report_tables:                       # optional
     columns: [<columnName>, ...]
     cells:
       <columnName>: <expression>
+pivot_tables:                        # optional
+  <pivotName>:
+    source: <tableName>
+    rows:
+      from: <columnName>|<tableName>.<columnName>
+      order: [<string>, ...]         # optional
+    columns:
+      from: <columnName>|<tableName>.<columnName>
+      range:                         # optional
+        start: YYYY-MM-DD
+        end: YYYY-MM-DD
+        step: day|week|month         # optional, default: day
+      label: iso_date|short_month_day  # optional, default: iso_date
+    value: sum(<columnName>)
+    key: <columnName>                # optional, default: source table key
+    empty_cells: null|zero|empty-string|error  # optional, default: null
+    totals:                          # optional
+      row: <name>
+      column:
+        <rowName>:
+          mode: sum|running_sum      # optional, default: sum
 ---
 
 # Markdown body (data + presentation)
@@ -53,6 +74,14 @@ report_tables:                       # optional
 - `report_tables.<name>.columns` defines rendered column order.
 - `report_tables.<name>.cells` must define one expression per rendered column.
 - `report_tables.<name>.key` is optional and defaults to the key of the `rows_from` source table.
+- `pivot_tables` defines synthetic 2-D matrices rendered at matching headings.
+- `pivot_tables.<name>.source` must reference an authored table.
+- `pivot_tables.<name>.rows.from` and `.columns.from` accept either a source column name or `table.column` reference to an authored table.
+- `pivot_tables.<name>.columns.range` is optional and requires ISO dates (`YYYY-MM-DD`) with `start <= end`; `step` is `day`, `week`, or `month`.
+- `pivot_tables.<name>.columns.label` supports `iso_date` and `short_month_day`.
+- `pivot_tables.<name>.value` in v1 must be `sum(<column>)` where `<column>` exists in the source table.
+- `pivot_tables.<name>.totals.row` defines the synthesized trailing row-total column name (it is not required to be a source-table column).
+- `pivot_tables.<name>.totals.column.<name>.mode` supports `sum` and `running_sum` footer rows.
 
 ## Markdown Body Rules
 - Contains only literal values; no inline formulas or expressions.
@@ -60,6 +89,7 @@ report_tables:                       # optional
 - Empty cells adopt `empty_cells` policy.
 - Tables are keyed by the `key` column; key values must be unique per table.
 - A heading whose text matches a `report_tables` name is a render target for that synthetic report table.
+- A heading whose text matches a `pivot_tables` name is a render target for that synthetic pivot table.
 
 ## Data Types
 - Primitive types: `number` (IEEE-754), `string` (UTF-8 text), `bool` (`true`/`false`), `date` (ISO-8601 `YYYY-MM-DD`).
@@ -157,7 +187,8 @@ arguments   ::= expression ( "," expression )*
 4) Evaluate aggregates over final column values.
 5) Evaluate `summary_rows` cell expressions in declaration order.
 6) Evaluate `report_tables` rows from their `rows_from` source tables.
-7) Render outputs (computed columns/summary rows/report tables/interpolation, exports).
+7) Evaluate `pivot_tables` row/column axes, cells, and totals.
+8) Render outputs (computed columns/summary rows/report tables/pivot tables/interpolation, exports).
 
 ### Aggregate Null Handling
 - Aggregates skip null inputs.

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -46,7 +46,6 @@ pivot_tables:                        # optional
         step: day|week|month         # optional, default: day
       label: iso_date|short_month_day  # optional, default: iso_date
     value: sum(<columnName>)
-    key: <columnName>                # optional, default: source table key
     empty_cells: null|zero|empty-string|error  # optional, default: null
     totals:                          # optional
       row: <name>

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -75,7 +75,7 @@ pivot_tables:                        # optional
 - `report_tables.<name>.key` is optional and defaults to the key of the `rows_from` source table.
 - `pivot_tables` defines synthetic 2-D matrices rendered at matching headings.
 - `pivot_tables.<name>.source` must reference an authored table.
-- `pivot_tables.<name>.rows.from` and `.columns.from` accept either a source column name or `table.column` reference to an authored table.
+- `pivot_tables.<name>.rows.from` and `.columns.from` accept either a source column name or `table.column` reference to an authored table; when using `table.column`, the referenced column name must also exist in the pivot `source` table schema.
 - `pivot_tables.<name>.columns.range` is optional and requires ISO dates (`YYYY-MM-DD`) with `start <= end`; `step` is `day`, `week`, or `month`.
 - `pivot_tables.<name>.columns.label` supports `iso_date` and `short_month_day`.
 - `pivot_tables.<name>.value` in v1 must be `sum(<column>)` where `<column>` exists in the source table.

--- a/specs/formal-format-spec.md
+++ b/specs/formal-format-spec.md
@@ -13,7 +13,7 @@ tables:
   <tableName>:
     key: <columnName>                # optional, default: id
     columns: [<columnName>, ...]
-    empty_cells: null|zero|empty-string|error  # optional, default: null
+    empty_cells: "null"|"zero"|"empty-string"|"error"  # optional; omit field for default null behavior
     types:                           # optional
       <columnName>: number|string|bool|date
     computed:                        # optional
@@ -46,7 +46,7 @@ pivot_tables:                        # optional
         step: day|week|month         # optional, default: day
       label: iso_date|short_month_day  # optional, default: iso_date
     value: sum(<columnName>)
-    empty_cells: null|zero|empty-string|error  # optional, default: null
+    empty_cells: "null"|"zero"|"empty-string"|"error"  # optional; omit field for default null behavior
     totals:                          # optional
       row: <name>
       column:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": ["ES2020"],
     "types": ["node"],
     "strict": true,


### PR DESCRIPTION
## Summary
- add pivot_tables frontmatter support with validation and diagnostics
- implement pivot evaluation (axes, cell aggregation, row totals, running-sum footer)
- inject rendered pivot markdown at matching headings
- add synthetic dependency-order planning hooks for report/pivot evaluation
- update docs/spec with pivot schema and evaluation order
- add VS Code tooling polish: pivot snippets, schema command inclusion, heading hover/completion for synthetic tables
- add comprehensive test coverage for core and extension updates

## Validation
- npm run -w @mdxtab/core test
- npm run -w @mdxtab/core build
- npm run -w mdxtab test
- npm run -w mdxtab build